### PR TITLE
Changes for plugin

### DIFF
--- a/renderchan/contrib/synfig.py
+++ b/renderchan/contrib/synfig.py
@@ -1,6 +1,7 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
+from renderchan.utils import is_true_string
 import subprocess
 import gzip
 import os, sys
@@ -173,7 +174,7 @@ class RenderChanSynfigModule(RenderChanModule):
             commandline.append("--time")
             commandline.append(extraParams["single"]+"f")
 
-        if extraParams["extract_alpha"] == "1":
+        if is_true_string(extraParams["extract_alpha"]):
             commandline.append("-x")
 
         commandline.append(filename)

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -363,6 +363,9 @@ class RenderChan():
 
         isDirty = isDirty or isDirtyValue
         
+        # Mark this file as already parsed and thus its "dirty" value is known
+        taskfile.isDirty=isDirty
+        
         if not shouldRender:
             return isDirty
 
@@ -527,9 +530,6 @@ class RenderChan():
 
                     if self.childTask!=None:
                         self.graph.addEdges( [(self.childTask, task)] )
-
-        # Mark this file as already parsed and thus its "dirty" value is known
-        taskfile.isDirty=isDirty
 
         return isDirty
 

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -123,6 +123,18 @@ class RenderChan():
             print("ERROR: Can't render a file which is not a part of renderchan project.")
             print()
             return 1
+        
+        if not taskfile.module:
+            print()
+            extension = os.path.splitext(taskfile.getPath())[1]
+            if extension:
+                print("ERROR: The '%s' file type was not recoginized." % extension)
+            else:
+                print("ERROR: The provided file does not have an extension.")
+            print()
+            return 1
+        else:
+            print("Taskfile is valid")
 
         if self.renderfarm_engine=="afanasy":
 

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -10,6 +10,7 @@ from renderchan.utils import sync
 from renderchan.utils import touch
 from renderchan.utils import copytree
 from renderchan.utils import which
+from renderchan.utils import is_true_string
 import os, time
 import shutil
 import subprocess
@@ -390,7 +391,7 @@ class RenderChan():
                     f = open(output_list, 'a')
                     f.write("file '%s'\n" % (chunk_name))
                     f.close()
-                    if "extract_alpha" in params and params["extract_alpha"] == "1":
+                    if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
 
                         f = open(output_list_alpha, 'a')
                         alpha_output = os.path.splitext(chunk_name)[0] + "-alpha" + os.path.splitext(chunk_name)[1]
@@ -761,7 +762,7 @@ class RenderChan():
                                updateCompletion,
                                params)
                 touch(output+".done",compare_time)
-                if "extract_alpha" in params and params["extract_alpha"] == "1":
+                if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
                     alpha_output = os.path.splitext(output)[0] + "-alpha" + os.path.splitext(output)[1]
                     touch(alpha_output+".done",compare_time)
 
@@ -799,7 +800,7 @@ class RenderChan():
             params = taskfile.getParams()
 
             suffix_list = [""]
-            if "extract_alpha" in params and params["extract_alpha"] == "1":
+            if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
                 suffix_list.append("-alpha")
 
             for suffix in suffix_list:

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -378,25 +378,24 @@ class RenderChan():
             # Keep track of created files to allow merging them later
             output_list = os.path.splitext( taskfile.getProfileRenderPath() )[0] + ".txt"
             output_list_alpha = os.path.splitext( taskfile.getProfileRenderPath() )[0] + "-alpha.txt"
-            if os.path.exists(output_list):
-                os.remove(output_list)
-            if os.path.exists(output_list_alpha):
-                os.remove(output_list_alpha)
             if taskfile.getPacketSize() > 0:
                 segments = self.decompose(taskfile.getStartFrame(), taskfile.getEndFrame(), taskfile.getPacketSize())
-                for range in segments:
-                    start=range[0]
-                    end=range[1]
-                    chunk_name = taskfile.getProfileRenderPath(start,end)
-                    f = open(output_list, 'a')
-                    f.write("file '%s'\n" % (chunk_name))
+                f = open(output_list, 'w')
+                if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
+                    fa = open(output_list_alpha, 'w')
+                try:
+                    for range in segments:
+                        start=range[0]
+                        end=range[1]
+                        chunk_name = taskfile.getProfileRenderPath(start,end)
+                        f.write("file '%s'\n" % (chunk_name))
+                        if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
+                            alpha_output = os.path.splitext(chunk_name)[0] + "-alpha" + os.path.splitext(chunk_name)[1]
+                            fa.write("file '%s'\n" % (alpha_output))
+                finally:
                     f.close()
-                    if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
-
-                        f = open(output_list_alpha, 'a')
-                        alpha_output = os.path.splitext(chunk_name)[0] + "-alpha" + os.path.splitext(chunk_name)[1]
-                        f.write("file '%s'\n" % (alpha_output))
-                        f.close()
+                    if fa:
+                        fa.close()
             else:
                 segments=[ (None,None) ]
 

--- a/renderchan/joblauncher.py
+++ b/renderchan/joblauncher.py
@@ -78,7 +78,7 @@ def main(argv):
         if options.action == 'merge' and options.stereo and ( options.stereo[0:1]=="v" or options.stereo[0:1]=="h" ):
             pass
         else:
-            (isDirty, tasklist, maxTime)=renderchan.parseDirectDependency(taskfile, compare_time)
+            (isDirty, tasklist, maxTime)=renderchan.parseDirectDependency(taskfile, compare_time, True)
             if isDirty:
                 print("ERROR: There are unrendered dependencies for this file!")
                 print("       (Project tree changed or job started too early?)")

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -183,3 +183,8 @@ class LockThread(threading.Thread):
 def ini_wrapper(filename):
     ini_str = '[default]\n' + open(filename, 'r').read()
     return io.StringIO(ini_str)
+
+def is_true_string(string) {
+    string = string.lower()
+    return string == "1" or string == "true" or string == "yes"
+}

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -5,13 +5,13 @@ import random
 import time
 import threading
 import io
+import shutil
 
 if os.name == 'nt':
     import ctypes
     kdll = ctypes.windll.LoadLibrary("kernel32.dll")
 
 def which(program):
-
     def is_exe(fpath):
         if os.name=='nt':
             return os.path.isfile(fpath) or os.path.isfile(fpath+".exe") or os.path.isfile(fpath+".bat")
@@ -24,12 +24,9 @@ def which(program):
         if is_exe(program):
             return program
     else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            path = path.strip('"')
-            exe_file = os.path.join(path, program)
-            exe_file = os.path.realpath(exe_file)
-            if is_exe(exe_file):
-                return exe_file
+        path = shutil.which(program)
+        if path:
+            return os.path.realpath(path)
 
     return None
 

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -184,7 +184,6 @@ def ini_wrapper(filename):
     ini_str = '[default]\n' + open(filename, 'r').read()
     return io.StringIO(ini_str)
 
-def is_true_string(string) {
+def is_true_string(string):
     string = string.lower()
     return string == "1" or string == "true" or string == "yes"
-}


### PR DESCRIPTION
This is the first batch of changes needed for the plugin (#3). The following changes have been made:
- Added a shouldRender argument to parseRenderDependency and parseDirectDependency. If set to true (which it is for all existing internal calls) it behaves the same as before. If set to false, it will check for dirty files, but will not render anything.
- Minor refactoring. As I was going through the code, there were a few lines that I've cleaned up. Most notably, check out the modifications to the which util. I wasn't sure if it would work they way you want it to with windows, so I left the windows code in, but you should look into it. We may be able to replace that function entirely with the one from shutils.
- Added aliases for extract_alpha. This is (theoretically) the only change that affects the standalone behavior of renderchan. When working with conf files, you can now use "true" or "yes" in addition to the existing "1" to set boolean flags to true. Currently extract_alpha appears to be the only boolean setting, but there is a new utility function to make it easy to add new ones in the future.

I will push the latest code for the plugin once this stuff has been pulled. You may be interested to know that the latest code has a fully functional check for updated dependencies whenever a blend file is loaded ^_^

While I would not recommend using it for serious production yet, but as long as you make sure you backup everything beforehand I encourage you to try it out and let me know if there are any issue with that particular feature. The rest of the buttons and things don't work yet, so try not to press them.