### PR TITLE
Added new identifier support for stereo cameras

### DIFF
--- a/renderchan/contrib/blender.py
+++ b/renderchan/contrib/blender.py
@@ -81,9 +81,9 @@ class RenderChanBlenderModule(RenderChanModule):
 
         stereo_camera = ""
         if extraParams["stereo"]=="left":
-            stereo_camera = "Left"
+            stereo_camera = "left"
         elif extraParams["stereo"]=="right":
-            stereo_camera = "Right"
+            stereo_camera = "right"
 
         if (extraParams["disable_gpu"]!="False") or ('BLENDER_DISABLE_GPU' in os.environ):
             print("================== FORCE DISABLE GPU =====================")


### PR DESCRIPTION
It should support all of the Blender naming conventions now in addition to the old 'left' and 'right' camera names.

Closes #21 