### PR TITLE
Gimp module and use_own_dimensions

### DIFF
--- a/renderchan/contrib/gimp.py
+++ b/renderchan/contrib/gimp.py
@@ -17,6 +17,7 @@ class RenderChanGimpModule(RenderChanModule):
         else:
             self.conf['binary']="gimp"
         self.conf["packetSize"]=0
+        self.extraParams['use_own_dimensions'] = '1'
 
     def getInputFormats(self):
         return ["xcf", "fli", "flc", "dds", "dcm", "dicom", "eps", "fit", "fits", "g3", "xjt", "cel", "wmf", "ico", "pnm", "ppm", "pgm", "pbm", "psp", "psd", "pdf", "ps", "tiff", "bmp", "xbm", "xwd", "pcx", "pcc", "ora"]
@@ -28,19 +29,19 @@ class RenderChanGimpModule(RenderChanModule):
 
         comp=0.0
         updateCompletion(comp)
-        
+
         # Determines drawable (depending on layer support)
         if format in ("gif", "ico", "mng", "psd"):
             drawable="gimp-image-get-active-drawable image"
         else:
             drawable="gimp-image-merge-visible-layers image CLIP-TO-IMAGE"
-        
+
         # Preprocessing procedures
         if format == "gif":
             preprocedure="(gimp-image-convert-indexed image 0 0 255 0 0 \"\")"
         else:
             preprocedure=""
-        
+
         # Determine procedure name
         if format in ("png", "tiff"):
             saveProcedure="file-%s-save2" % format
@@ -54,7 +55,7 @@ class RenderChanGimpModule(RenderChanModule):
             saveProcedure="file-%s-save" % format
         else:
             saveProcedure="gimp-file-save"
-        
+
         # Determine paramters
         if format == "png":
             # PNG get special treatment because default parameters can be fetched from GIMP

--- a/renderchan/contrib/gimp.py
+++ b/renderchan/contrib/gimp.py
@@ -81,8 +81,14 @@ class RenderChanGimpModule(RenderChanModule):
         else:
             saveParameters=""
 
+        if extraParams['use_own_dimensions']:
+            width_arg = '(car (gimp-image-width image))'
+            height_arg = '(car (gimp-image-height image))'
+        else:
+            width_arg = extraParams['width']
+            width_arg = extraParams['height']
         # See docs for readable script-fu code
-        commandline=[self.conf['binary'], "-i", "-b", "(let*  ((filename \"%s\") (outpath \"%s\") (image (car (gimp-file-load RUN-NONINTERACTIVE filename filename))) (drawable (car (%s)))) %s (gimp-image-scale image %s %s) (%s RUN-NONINTERACTIVE image drawable outpath outpath %s) (gimp-image-delete image))" % (filename, outputPath, drawable, preprocedure, extraParams['width'], extraParams['height'], saveProcedure, saveParameters), "-b", "(gimp-quit 0)"]
+        commandline=[self.conf['binary'], "-i", "-b", "(let*  ((filename \"%s\") (outpath \"%s\") (image (car (gimp-file-load RUN-NONINTERACTIVE filename filename))) (drawable (car (%s)))) %s (gimp-image-scale image %s %s) (%s RUN-NONINTERACTIVE image drawable outpath outpath %s) (gimp-image-delete image))" % (filename, outputPath, drawable, preprocedure, width_arg, height_arg, saveProcedure, saveParameters), "-b", "(gimp-quit 0)"]
 
         subprocess.check_call(commandline)
 


### PR DESCRIPTION
# Defaults issue

The docs said Gimp and Krita defaulted to use_own_dimensions, but the gimp module did not. It seems the Krita module even forces the issue, actually. So I tried to bring the gimp module into line with this behaviour.

# Gimp scaling error

When using use_own_dimensions for gimp files, this happened to me both with gimp 2.8.22 and gimp 2.10.8:

```sh
Rendering: 0.0
GIMP-Error: Calling error for procedure 'gimp-image-scale':
Procedure 'gimp-image-scale' has been called with value '0' for argument 'new-width' (#2, type GimpInt32). This value is out of range.                                            

batch command experienced an execution error:
Error: Procedure execution of gimp-image-scale failed on invalid input arguments: Procedure 'gimp-image-scale' has been called with value '0' for argument 'new-width' (#2, type GimpInt32). This value is out of range.

/usr/bin/gimp-2.10: GEGL-WARNING: (gegl-tile-handler-cache.c:977):gegl_tile_cache_destroy: runtime check failed: (g_queue_is_empty (&cache_queue))                                
EEEEeEeek! 4 GeglBuffers leaked
Rendering: 100.0
Rendering: 100.0
Merging: /home/csp/pile/renderchan/tester/render/project.conf/profiles/1090x50.hd/img/octo-eyes.xcf.png                                                                           
ERROR: Not all segments were rendered. Aborting.
ERROR: Merge operation failed.

```

So I introduced a conditional to provide gimp with a new size equal to the starting dimensions in case of use_own_dimensions.