### PR TITLE
Improve recursive render robustness (hidden files, casing, error handling)

### DIFF
--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -183,6 +183,10 @@ def main(datadir, argv):
         renderchan.force_proxy = args.forceProxy
         
     if args.recursive:
+        if not os.path.isdir(filename):
+            print("ERROR: --recursive expects a directory, got a file: %s" % filename, file=sys.stderr)
+            return 1
+
         success = True
         renderDir = os.path.join(filename, "render") + os.path.sep
         formats = renderchan.modules.getAllInputFormats()

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -212,7 +212,8 @@ def main(datadir, argv):
                 if 'render' in (part.lower() for part in rel_parts):
                     continue
                 if os.path.isfile(file):
-                    if os.path.splitext(file)[1][1:] in formats:
+                    ext = os.path.splitext(file)[1][1:].lower()
+                    if ext in formats:
                         files.append(file)
                 if os.path.isdir(file):
                     dirs.append(file)

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -197,7 +197,19 @@ def main(datadir, argv):
             d = dirs.pop(0)
             for f in sorted(os.listdir(d)):
                 file = os.path.join(d, f)
-                if f[0] == '.' or file[0:len(renderDir)] == renderDir:
+                # Skip hidden entries, like .git, .svn, .DS_Store, etc.
+                if f[0] == '.':
+                    continue
+                # Skip symlinks
+                if os.path.islink(file):
+                    continue
+                try:
+                    rel_parts = os.path.relpath(file, filename).split(os.sep)
+                except ValueError:
+                    # Happens on Windows when crossing drive letters; skip to avoid crashing
+                    continue
+                # Skip anything under render/ directory
+                if 'render' in (part.lower() for part in rel_parts):
                     continue
                 if os.path.isfile(file):
                     if os.path.splitext(file)[1][1:] in formats:

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -220,9 +220,6 @@ def main(datadir, argv):
                 # Skip hidden entries, like .git, .svn, .DS_Store, etc.
                 if _is_hidden(file, f):
                     continue
-                # Skip symlinks
-                if os.path.islink(file):
-                    continue
                 try:
                     rel_parts = os.path.relpath(file, filename).split(os.sep)
                 except ValueError as e:

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -210,8 +210,9 @@ def main(datadir, argv):
                     continue
                 try:
                     rel_parts = os.path.relpath(file, filename).split(os.sep)
-                except ValueError:
+                except ValueError as e:
                     # Happens on Windows when crossing drive letters; skip to avoid crashing
+                    print("WARNING: Cannot build relative path for %s: %s" % (file, e), file=sys.stderr)
                     continue
                 # Skip anything under render/ directory
                 if 'render' in (part.lower() for part in rel_parts):

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -195,7 +195,12 @@ def main(datadir, argv):
         files = []
         while len(dirs):
             d = dirs.pop(0)
-            for f in sorted(os.listdir(d)):
+            try:
+                entries = sorted(os.listdir(d))
+            except OSError as e:
+                print("WARNING: Cannot list directory %s: %s" % (d, e), file=sys.stderr)
+                continue
+            for f in entries:
                 file = os.path.join(d, f)
                 # Skip hidden entries, like .git, .svn, .DS_Store, etc.
                 if f[0] == '.':

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -359,8 +359,9 @@ class RenderChan():
 
 
             # Make sure to close cache before submitting job to renderfarm
-            for path in self.projects.list.keys():
-                self.projects.list[path].cache.close()
+            if self.renderfarm_engine != "":
+                for path in self.projects.list.keys():
+                    self.projects.list[path].cache.close()
 
             # Submit job to renderfarm
             if self.renderfarm_engine=="afanasy":


### PR DESCRIPTION
Harden recursive render traversal: validate directory input, skip symlinks/hidden/system entries and render subtrees, and make extension filtering case-insensitive.

Add resilience: handle os.listdir failures with warnings, log relpath cross-drive issues on Windows instead of crashing, and improve hidden detection for Windows attributes.

Keep the cache open during local recursive renders to avoid closed-DB errors.