### PR TITLE
fix: pass formatted image sequence pattern to FFmpeg instead of direc…

### DIFF
--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -1161,7 +1161,11 @@ class RenderChan():
                                 ffmpeg_cmd.append("-r")
                                 ffmpeg_cmd.append(params["fps"])
                                 ffmpeg_cmd.append("-i")
-                                ffmpeg_cmd.append(segment)
+                                if os.path.isdir(segment):
+                                    digits = 4 if taskfile.project.version < 1 else 5
+                                    ffmpeg_cmd.append(os.path.join(segment, f"file.%0{digits}d.{profile_output_format}"))
+                                else:
+                                    ffmpeg_cmd.append(segment)
                                 ffmpeg_cmd.append("-c:v")
                                 ffmpeg_cmd.append("prores_ks")
                                 ffmpeg_cmd.append("-profile:v")


### PR DESCRIPTION
Core / Merge: Fixed video merging failure for renders without packet-splitting (packet size = 0). 

FFmpeg is now correctly supplied with an image sequence pattern (e.g., [file.%05d.png]) instead of a raw directory path.