### PR TITLE
feat: New console UI - animated progress bar and quiet/verbose output modes

### DIFF
--- a/renderchan/cache.py
+++ b/renderchan/cache.py
@@ -8,6 +8,7 @@ import socket
 import tempfile
 import time
 from renderchan.utils import mkdirs, LockThread
+from renderchan import ui
 
 LOCK_STALE_TIMEOUT = 300      # seconds; lock not updated for this long is assumed stale
 LOCK_HEARTBEAT_INTERVAL = 60  # seconds between lockfile mtime updates
@@ -45,9 +46,9 @@ class RenderChanCache():
             self.closed = False
 
         except sqlite3.Error as e:
-            print("ERROR: Cannot initialize cache database.")
-            print("SQLite error: %s" % e.args[0])
-            print("Cache file path: %s" % self.local_path)
+            ui.error("Cannot initialize cache database.")
+            ui.error("SQLite error: %s" % e.args[0])
+            ui.error("Cache file path: %s" % self.local_path)
 
     def _acquire_lock(self):
         if os.path.exists(self.lockfile):
@@ -55,11 +56,11 @@ class RenderChanCache():
             lock_age = time.time() - lock_mtime
             if lock_age >= LOCK_STALE_TIMEOUT:
                 lock_time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(lock_mtime))
-                print("WARNING: Cache lock is stale (last updated %s), removing: %s" % (lock_time_str, self.lockfile))
+                ui.warn("Cache lock is stale (last updated %s), removing: %s" % (lock_time_str, self.lockfile))
                 try:
                     os.remove(self.lockfile)
                 except Exception:
-                    print("ERROR: Cannot remove stale lock file: %s" % self.lockfile)
+                    ui.error("Cannot remove stale lock file: %s" % self.lockfile)
                     return False
             else:
                 try:
@@ -67,15 +68,15 @@ class RenderChanCache():
                         locked_by = f.read().strip()
                 except Exception:
                     locked_by = "(unknown)"
-                print("ERROR: Cache is locked by '%s' (%.0f s ago)." % (locked_by, lock_age))
-                print("If the lock is stale, delete the lock file:")
-                print("  %s" % self.lockfile)
+                ui.error("Cache is locked by '%s' (%.0f s ago)." % (locked_by, lock_age))
+                ui.error("If the lock is stale, delete the lock file:")
+                ui.error("  %s" % self.lockfile)
                 return False
         try:
             with open(self.lockfile, 'w') as f:
                 f.write("%s:%d\n" % (socket.gethostname(), os.getpid()))
         except Exception:
-            print("ERROR: Cannot create lock file: %s" % self.lockfile)
+            ui.error("Cannot create lock file: %s" % self.lockfile)
             return False
         self._lock_heartbeat = LockThread(self.lockfile, interval=LOCK_HEARTBEAT_INTERVAL)
         self._lock_heartbeat.start()
@@ -89,7 +90,7 @@ class RenderChanCache():
             if os.path.exists(self.lockfile):
                 os.remove(self.lockfile)
         except Exception as e:
-            print("WARNING: Cannot remove lock file '%s': %s" % (self.lockfile, e))
+            ui.warn("Cannot remove lock file '%s': %s" % (self.lockfile, e))
 
     def __del__(self):
         if not self.closed:
@@ -104,7 +105,7 @@ class RenderChanCache():
             try:
                 shutil.copy(self.local_path, self.path)
             except Exception as e:
-                print("ERROR: Cannot save cache to '%s': %s" % (self.path, e))
+                ui.error("Cannot save cache to '%s': %s" % (self.path, e))
             self._release_lock()
 
         try:
@@ -113,7 +114,7 @@ class RenderChanCache():
         except Exception:
             pass
 
-        print("Cache closed.")
+        ui.info("Cache closed.")
 
     def getInfo(self, path):
         if self.closed:
@@ -133,7 +134,7 @@ class RenderChanCache():
             else:
                 return None
         except:
-            print("ERROR: Cannot read from database.", file=sys.stderr)
+            ui.error("Cannot read from database.", stderr=True)
             return None
 
     def getDependencies(self, path):
@@ -155,12 +156,12 @@ class RenderChanCache():
             else:
                 return None
         except:
-            print("ERROR: Cannot read from database.")
+            ui.error("Cannot read from database.")
             return None
 
     def write(self, path, timestamp, start, end, dependencies, width, height):
         if self.closed:
-            print("ERROR: Database is closed. Writing isn't possible.")
+            ui.error("Database is closed. Writing isn't possible.")
             return None
 
         if not self.readonly and not self._locked:
@@ -199,4 +200,4 @@ class RenderChanCache():
         try:
             self.connection.commit()
         except:
-            print("ERROR: Cannot write into database.")
+            ui.error("Cannot write into database.")

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -150,7 +150,7 @@ def main(datadir, argv):
     args = process_args(datadir)
 
     ui.set_verbose(args.verbose)
-    ui._safe_write("\n")
+    ui.quiet_blank()
     ui.intro("RenderChan v%s" % __version__, animate=True)
 
     filename = os.path.abspath(args.file)

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -150,6 +150,7 @@ def main(datadir, argv):
     args = process_args(datadir)
 
     ui.set_verbose(args.verbose)
+    ui._safe_write("\n")
     ui.intro("RenderChan v%s" % __version__)
 
     filename = os.path.abspath(args.file)

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -150,8 +150,14 @@ def main(datadir, argv):
     args = process_args(datadir)
 
     ui.set_verbose(args.verbose)
+    ui.intro("RenderChan v%s" % __version__)
 
     filename = os.path.abspath(args.file)
+
+    if not args.recursive:
+        ui.rail_blank()
+        ui.log_info(os.path.basename(filename))
+        ui.rail_blank()
 
     renderchan = RenderChan()
 
@@ -260,7 +266,7 @@ def main(datadir, argv):
 
     ui.progress_stop()
     if result in (0, None):
-        ui.outro(_("Done in %s") % ui.format_duration(time.time() - renderchan.start_time))
+        ui.outro(_("Completed in %s") % ui.format_duration(time.time() - renderchan.start_time))
     else:
         ui.outro(_("Failed"))
     return result

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -9,6 +9,7 @@ import sys
 import stat
 
 from renderchan.core import RenderChan, __version__
+from renderchan import ui
 
 
 def _is_hidden(path, name):
@@ -19,7 +20,7 @@ def _is_hidden(path, name):
         try:
             attrs = os.stat(path, follow_symlinks=False).st_file_attributes
         except OSError as e:
-            print("WARNING: Cannot stat %s: %s" % (path, e), file=sys.stderr)
+            ui.warn("Cannot stat %s: %s" % (path, e))
             return False
         return bool(attrs & (stat.FILE_ATTRIBUTE_HIDDEN | stat.FILE_ATTRIBUTE_SYSTEM))
     return False
@@ -160,20 +161,20 @@ def main(datadir, argv):
             if args.renderfarm_engine in ("puli"):
                 renderchan.setHost(args.host)
             else:
-                print("WARNING: The --host parameter cannot be set for this type of renderfarm.")
+                ui.warn("The --host parameter cannot be set for this type of renderfarm.")
         if args.port:
             if renderchan.renderfarm_engine in ("puli"):
                 renderchan.setPort(args.port)
             else:
-                print("WARNING: The --port parameter cannot be set for this type of renderfarm.")
+                ui.warn("The --port parameter cannot be set for this type of renderfarm.")
 
         if args.cgru_location:
             renderchan.cgru_location = args.cgru_location
     else:
         if args.host:
-            print("WARNING: No renderfarm type given. Ignoring --host parameter.")
+            ui.warn("No renderfarm type given. Ignoring --host parameter.")
         if args.port:
-            print("WARNING: No renderfarm type given. Ignoring --port parameter.")
+            ui.warn("No renderfarm type given. Ignoring --port parameter.")
 
     if args.snapshot_to:
         renderchan.snapshot_path = args.snapshot_to
@@ -199,7 +200,7 @@ def main(datadir, argv):
         
     if args.recursive:
         if not os.path.isdir(filename):
-            print("ERROR: --recursive expects a directory, got a file: %s" % filename, file=sys.stderr)
+            ui.error("--recursive expects a directory, got a file: %s" % filename, stderr=True)
             return 1
 
         success = True
@@ -213,7 +214,7 @@ def main(datadir, argv):
             try:
                 entries = sorted(os.listdir(d))
             except OSError as e:
-                print("WARNING: Cannot list directory %s: %s" % (d, e), file=sys.stderr)
+                ui.warn("Cannot list directory %s: %s" % (d, e))
                 continue
             for f in entries:
                 file = os.path.join(d, f)
@@ -224,7 +225,7 @@ def main(datadir, argv):
                     rel_parts = os.path.relpath(file, filename).split(os.sep)
                 except ValueError as e:
                     # Happens on Windows when crossing drive letters; skip to avoid crashing
-                    print("WARNING: Cannot build relative path for %s: %s" % (file, e), file=sys.stderr)
+                    ui.warn("Cannot build relative path for %s: %s" % (file, e))
                     continue
                 # Skip anything under render/ directory
                 if 'render' in (part.lower() for part in rel_parts):
@@ -238,12 +239,12 @@ def main(datadir, argv):
                     
         for file in files:
             try:
-                print(_("Process file: %s") % (file))
+                ui.info(_("Process file: %s") % (file))
                 renderchan.submit(file, args.dependenciesOnly, args.allocateOnly, args.stereo)
             except:
                 while renderchan.trackedFilesStack:
                     renderchan.trackFileEnd()
-                print(_("Rendering failed for file: %s") % (file))
+                ui.error(_("Rendering failed for file: %s") % (file))
                 success = False
         return 0 if success else 1
 

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -151,7 +151,7 @@ def main(datadir, argv):
 
     ui.set_verbose(args.verbose)
     ui._safe_write("\n")
-    ui.intro("RenderChan v%s" % __version__)
+    ui.intro("RenderChan v%s" % __version__, animate=True)
 
     filename = os.path.abspath(args.file)
 

--- a/renderchan/cli.py
+++ b/renderchan/cli.py
@@ -7,6 +7,7 @@ from argparse import SUPPRESS
 import os
 import sys
 import stat
+import time
 
 from renderchan.core import RenderChan, __version__
 from renderchan import ui
@@ -122,6 +123,10 @@ def process_args(datadir):
             action="store_true",
             default=False,
             help=_("Parse files, but don't render anything."))
+    parser.add_argument("--verbose", dest="verbose",
+            action="store_true",
+            default=False,
+            help=_("Verbose output (the historical plain-text format)."))
     parser.add_argument("--recursive", dest="recursive",
             action="store_true",
             default=False,
@@ -143,6 +148,8 @@ def process_args(datadir):
 
 def main(datadir, argv):
     args = process_args(datadir)
+
+    ui.set_verbose(args.verbose)
 
     filename = os.path.abspath(args.file)
 
@@ -240,12 +247,20 @@ def main(datadir, argv):
         for file in files:
             try:
                 ui.info(_("Process file: %s") % (file))
+                ui.log_info(file)
                 renderchan.submit(file, args.dependenciesOnly, args.allocateOnly, args.stereo)
             except:
                 while renderchan.trackedFilesStack:
                     renderchan.trackFileEnd()
                 ui.error(_("Rendering failed for file: %s") % (file))
                 success = False
-        return 0 if success else 1
+        result = 0 if success else 1
+    else:
+        result = renderchan.submit(filename, args.dependenciesOnly, args.allocateOnly, args.stereo)
 
-    return renderchan.submit(filename, args.dependenciesOnly, args.allocateOnly, args.stereo)
+    ui.progress_stop()
+    if result in (0, None):
+        ui.outro(_("Done in %s") % ui.format_duration(time.time() - renderchan.start_time))
+    else:
+        ui.outro(_("Failed"))
+    return result

--- a/renderchan/contrib/animestudio9.py
+++ b/renderchan/contrib/animestudio9.py
@@ -2,6 +2,7 @@ __author__ = '036006'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import is_true_string
+from renderchan import ui
 import subprocess
 import os, sys
 import errno
@@ -37,7 +38,7 @@ class RenderChanAnimestudio9Module(RenderChanModule):
         try:
             lines = self._read_file_lines(filename)
         except IOError as e:
-            print("Error reading AnimeStudio9 file %s: %s" % (filename, str(e)))
+            ui.error("Error reading AnimeStudio9 file %s: %s" % (filename, str(e)))
             return info
 
         frame_pattern = re.compile(r"^frame_range\s+(\d+)\s+(\d+)")
@@ -66,7 +67,7 @@ class RenderChanAnimestudio9Module(RenderChanModule):
             if match:
                 info["fps"] = int(match.group(1))
                 self._last_fps = info["fps"]
-                print("    AnimeStudio9 fps: %d" % info["fps"])
+                ui.info("    AnimeStudio9 fps: %d" % info["fps"])
                 continue
 
             match = dimensions_pattern.match(stripped)
@@ -87,7 +88,7 @@ class RenderChanAnimestudio9Module(RenderChanModule):
             self._last_fps = None
 
         if len(dependencies) > 0:
-            print("    AnimeStudio9 dependencies: %d" % len(dependencies))
+            ui.info("    AnimeStudio9 dependencies: %d" % len(dependencies))
             info["dependencies"] = dependencies
         return info
 
@@ -106,21 +107,21 @@ class RenderChanAnimestudio9Module(RenderChanModule):
         layer_comp_enabled = is_true_string(layer_comp_value) or layer_comp_value.upper() == "ALL"
 
         if layer_comp_enabled:
-            print('====================================================')
-            print('  AnimeStudio9 layer_composition: enabled (%s)' % layer_comp_value)
+            ui.info('====================================================')
+            ui.info('  AnimeStudio9 layer_composition: enabled (%s)' % layer_comp_value)
             if file_lines is None:
                 file_lines = self._read_file_lines(filename)
             compositions = self._parse_layer_compositions(file_lines)
             target_folder = outputPath
 
             comp_names = [name for name, _ in compositions]
-            print('====================================================')
-            print('  AnimeStudio9 compositions: %d' % len(comp_names))
+            ui.info('====================================================')
+            ui.info('  AnimeStudio9 compositions: %d' % len(comp_names))
             if comp_names:
-                print('   ' + ', '.join(comp_names))
+                ui.info('   ' + ', '.join(comp_names))
             else:
-                print('   (no compositions found)')
-            print('====================================================')
+                ui.info('   (no compositions found)')
+            ui.info('====================================================')
 
             if compositions:
                 for comp_name, layer_ids in compositions:
@@ -130,9 +131,9 @@ class RenderChanAnimestudio9Module(RenderChanModule):
             else:
                 render_tasks.append((filename, target_folder))
         else:
-            print('====================================================')
-            print('  AnimeStudio9 layer_composition: DISABLED')
-            print('====================================================')
+            ui.info('====================================================')
+            ui.info('  AnimeStudio9 layer_composition: DISABLED')
+            ui.info('====================================================')
             render_tasks.append((filename, outputPath))
 
         total_tasks = float(len(render_tasks))
@@ -195,10 +196,10 @@ class RenderChanAnimestudio9Module(RenderChanModule):
             commandline.append("-halfsize")
             commandline.append("yes")
 
-        print('====================================================')
-        print('  AnimeStudio9 Render Command:')
-        print('  ' + ' '.join(commandline))
-        print('====================================================')
+        ui.info('====================================================')
+        ui.info('  AnimeStudio9 Render Command:')
+        ui.info('  ' + ' '.join(commandline))
+        ui.info('====================================================')
 
         out = subprocess.Popen(commandline, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         rc = None
@@ -216,17 +217,17 @@ class RenderChanAnimestudio9Module(RenderChanModule):
                     rc = out.poll()
                     continue
 
-                print(line_decoded, end='')
+                ui.info(line_decoded.rstrip())
                 sys.stdout.flush()
 
                 rc = out.poll()
 
-        print('====================================================')
+        ui.info('====================================================')
         if rc == 0:
-            print('  AnimeStudio9 render completed successfully')
+            ui.info('  AnimeStudio9 render completed successfully')
         else:
-            print('  AnimeStudio9 command returns with code %d' % rc)
-        print('====================================================')
+            ui.info('  AnimeStudio9 command returns with code %d' % rc)
+        ui.info('====================================================')
 
         if rc != 0:
             raise Exception('AnimeStudio9 render failed with exit code %d' % rc)

--- a/renderchan/contrib/animestudio9.py
+++ b/renderchan/contrib/animestudio9.py
@@ -5,6 +5,7 @@ from renderchan.utils import is_true_string
 from renderchan import ui
 import subprocess
 import os, sys
+import threading
 import errno
 import re
 import locale
@@ -99,6 +100,7 @@ class RenderChanAnimestudio9Module(RenderChanModule):
 
         render_tasks = []
         temp_files = []
+        comp_names = []
 
         fps_value = self._last_fps if self._last_fps is not None else 24
         file_lines = None
@@ -140,10 +142,23 @@ class RenderChanAnimestudio9Module(RenderChanModule):
         completed = 0.0
 
         try:
+            grand = 0.0
+            task_frames = []
             for target_file, target_output in render_tasks:
-                self._render_single(target_file, target_output, extraParams, fps_value, startFrame, endFrame)
-                completed += 1.0
-                updateCompletion(completed / total_tasks)
+                frames = self._frame_range(target_file)
+                task_frames.append(frames)
+                grand += frames
+            if grand <= 0:
+                grand = 1.0
+            done_frames = 0.0
+            for i, (target_file, target_output) in enumerate(render_tasks):
+                if i < len(comp_names):
+                    ui.progress_label("Rendering " + comp_names[i])
+                cb = (lambda base=done_frames, tf=task_frames[i]: (
+                    lambda produced: updateCompletion((base + produced) / grand)))()
+                self._render_single(target_file, target_output, extraParams, fps_value, startFrame, endFrame, progress_cb=cb)
+                done_frames += task_frames[i]
+                updateCompletion(done_frames / grand)
 
             if not render_tasks:
                 updateCompletion(1)
@@ -154,7 +169,30 @@ class RenderChanAnimestudio9Module(RenderChanModule):
                 except OSError:
                     pass
 
-    def _render_single(self, filename, outputPath, extraParams, fps_value, startFrame=None, endFrame=None):
+    def _frame_range(self, path):
+        try:
+            with open(path, 'rb') as f:
+                text = f.read().decode('utf-8', errors='replace')
+        except (IOError, OSError):
+            return 0
+        m = re.search(r"frame_range\s+(\d+)\s+(\d+)", text)
+        if m:
+            return int(m.group(2)) - int(m.group(1)) + 1
+        return 0
+
+    def _poll_frames(self, outputPath, existing_pngs, total_frames, progress_cb, stop):
+        last = -1
+        while not stop.is_set():
+            try:
+                count = len([f for f in os.listdir(outputPath) if f.endswith(".png")]) - len(existing_pngs)
+            except OSError:
+                count = last
+            if count != last and count >= 0:
+                last = count
+                progress_cb(min(count, total_frames))
+            stop.wait(0.5)
+
+    def _render_single(self, filename, outputPath, extraParams, fps_value, startFrame=None, endFrame=None, progress_cb=None):
 
         existing_pngs = set()
         if os.path.isdir(outputPath):
@@ -202,25 +240,41 @@ class RenderChanAnimestudio9Module(RenderChanModule):
         ui.info('====================================================')
 
         out = subprocess.Popen(commandline, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        rc = None
-        while True:
-                line = out.stdout.readline()
-                if not line:
-                        if rc is not None:
-                                break
-                try:
-                    line_decoded = line.decode(locale.getpreferredencoding() or 'utf-8')
-                except:
-                    line_decoded = line.decode('latin-1')
 
-                if "send_buffer Failed to get a sample" in line_decoded:
+        total_frames = self._frame_range(filename)
+        if total_frames <= 0 and startFrame is not None and endFrame is not None:
+            total_frames = endFrame - startFrame + 1
+        stop_polling = threading.Event()
+        poller = None
+        if progress_cb and total_frames > 0:
+            poller = threading.Thread(target=self._poll_frames,
+                                      args=(outputPath, existing_pngs, total_frames, progress_cb, stop_polling),
+                                      daemon=True)
+            poller.start()
+        try:
+            rc = None
+            while True:
+                    line = out.stdout.readline()
+                    if not line:
+                            if rc is not None:
+                                    break
+                    try:
+                        line_decoded = line.decode(locale.getpreferredencoding() or 'utf-8')
+                    except:
+                        line_decoded = line.decode('latin-1')
+
+                    if "send_buffer Failed to get a sample" in line_decoded:
+                        rc = out.poll()
+                        continue
+
+                    ui.info(line_decoded.rstrip())
+                    sys.stdout.flush()
+
                     rc = out.poll()
-                    continue
-
-                ui.info(line_decoded.rstrip())
-                sys.stdout.flush()
-
-                rc = out.poll()
+        finally:
+            stop_polling.set()
+            if poller is not None:
+                poller.join(timeout=1)
 
         ui.info('====================================================')
         if rc == 0:

--- a/renderchan/contrib/blender.py
+++ b/renderchan/contrib/blender.py
@@ -1,6 +1,7 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
+from renderchan import ui
 import subprocess
 import os, sys
 import re
@@ -68,7 +69,7 @@ class RenderChanBlenderModule(RenderChanModule):
             rc = out.poll()
 
         if rc != 0:
-            print("  Blender command failed (exit code %d)!" % rc)
+            ui.error("Blender command failed (exit code %d)!" % rc)
 
         return info
 
@@ -89,7 +90,7 @@ class RenderChanBlenderModule(RenderChanModule):
             stereo_camera = "right"
 
         if (extraParams["disable_gpu"]!="False") or ('BLENDER_DISABLE_GPU' in os.environ):
-            print("================== FORCE DISABLE GPU =====================")
+            ui.info("================== FORCE DISABLE GPU =====================")
             gpu_device='None'
         else:
             gpu_device='"'+self.conf["gpu_device"]+'"'
@@ -118,9 +119,9 @@ class RenderChanBlenderModule(RenderChanModule):
             else:
                 outputPath=os.path.join(outputPath, "file")+".#####"
 
-        print('====================================================')
-        print('  Output Path: %s' % outputPath)
-        print('====================================================')
+        ui.info('====================================================')
+        ui.info('  Output Path: %s' % outputPath)
+        ui.info('====================================================')
 
         env=os.environ.copy()
         env["PYTHONPATH"]=""
@@ -152,7 +153,7 @@ class RenderChanBlenderModule(RenderChanModule):
                     break
             line = line.decode(sys.stdout.encoding)
 
-            print(line, end=' ')
+            ui.info(line.rstrip())
             sys.stdout.flush()
 
             if line.startswith("CUDA error: Out of memory"):
@@ -174,9 +175,9 @@ class RenderChanBlenderModule(RenderChanModule):
                         updateCompletion(comp + fc)
             rc = out.poll()
 
-        print('====================================================')
-        print('  Blender command returns with code %d' % rc)
-        print('====================================================')
+        ui.info('====================================================')
+        ui.info('  Blender command returns with code %d' % rc)
+        ui.info('====================================================')
 
         if format in RenderChanModule.imageExtensions and extraParams["single"]!="None":
             outputPath=outputPath[:-7]
@@ -184,7 +185,7 @@ class RenderChanBlenderModule(RenderChanModule):
             os.rename(tmp, outputPath)
 
         if rc != 0:
-            print('  Blender command failed...')
+            ui.error('Blender command failed...')
             raise Exception('  Blender command failed...')
 
         os.remove(renderscript)

--- a/renderchan/contrib/blender.py
+++ b/renderchan/contrib/blender.py
@@ -31,9 +31,9 @@ class RenderChanBlenderModule(RenderChanModule):
         info={"dependencies":[]}
 
         script=os.path.join(os.path.dirname(__file__),"blender","analyze.py")
-        dependencyPattern = re.compile("RenderChan dependency: (.*)$")
-        startFramePattern = re.compile("RenderChan start: (.*)$")
-        endFramePattern = re.compile("RenderChan end: (.*)$")
+        dependencyPattern = re.compile(r"RenderChan dependency: (.*)$")
+        startFramePattern = re.compile(r"RenderChan start: (.*)$")
+        endFramePattern = re.compile(r"RenderChan end: (.*)$")
 
         env=os.environ.copy()
         env["PYTHONPATH"]=""
@@ -79,9 +79,9 @@ class RenderChanBlenderModule(RenderChanModule):
         updateCompletion(comp)
 
         totalFrames = endFrame - startFrame + 1
-        frameCompletionPattern = re.compile("Saved:(\d+) Time: .* \(Saving: .*\)")
-        frameCompletionPattern2 = re.compile("Append frame (\d+) Time: .* \(Saving: .*\)")
-        frameNumberPattern = re.compile("Fra:(\d+) Mem:.*")
+        frameCompletionPattern = re.compile(r"Saved:(\d+) Time: .* \(Saving: .*\)")
+        frameCompletionPattern2 = re.compile(r"Append frame (\d+) Time: .* \(Saving: .*\)")
+        frameNumberPattern = re.compile(r"Fra:(\d+) Mem:.*")
 
         stereo_camera = ""
         if extraParams["stereo"]=="left":

--- a/renderchan/contrib/ffmpeg.py
+++ b/renderchan/contrib/ffmpeg.py
@@ -4,6 +4,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import which
+from renderchan import ui
 import subprocess
 import os
 import random
@@ -30,6 +31,6 @@ class RenderChanFfmpegModule(RenderChanModule):
         # TODO: Progress callback
 
         commandline=[self.conf['binary'], "-i", filename, os.path.join(outputPath,"output_%04d.png")]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         updateCompletion(1.0)

--- a/renderchan/contrib/flac.py
+++ b/renderchan/contrib/flac.py
@@ -4,6 +4,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import which
+from renderchan import ui
 import subprocess
 import os
 import random
@@ -24,13 +25,13 @@ class RenderChanFlacModule(RenderChanModule):
     def checkRequirements(self):
         if which(self.conf['binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
-            print("    Please install flac package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
+            ui.info("    Please install flac package.")
             return False
         if which(self.conf['sox_binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
-            print("    Please install sox package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
+            ui.info("    Please install sox package.")
             return False
         self.active=True
         return True
@@ -45,10 +46,10 @@ class RenderChanFlacModule(RenderChanModule):
         # TODO: Progress callback
 
         commandline=[self.conf['binary'], "-d", filename, "-o", tmpfile]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         commandline=[self.conf['sox_binary'], tmpfile, outputPath, "rate", "-v", extraParams["audio_rate"]]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         os.remove(tmpfile)
 

--- a/renderchan/contrib/gimp.py
+++ b/renderchan/contrib/gimp.py
@@ -4,6 +4,7 @@ __author__ = 'scribblemaniac'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import which
+from renderchan import ui
 import subprocess
 import os
 import re
@@ -87,6 +88,6 @@ class RenderChanGimpModule(RenderChanModule):
         # See docs for readable script-fu code
         commandline=[self.conf['binary'], "-i", "-b", "(let*  ((filename \"%s\") (outpath \"%s\") (image (car (gimp-file-load RUN-NONINTERACTIVE filename filename))) (drawable (car (%s)))) %s (gimp-image-scale image %s %s) (%s RUN-NONINTERACTIVE image drawable outpath outpath %s) (gimp-image-delete image))" % (filename, outputPath, drawable, preprocedure, width_arg, height_arg, saveProcedure, saveParameters), "-b", "(gimp-quit 0)"]
 
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         updateCompletion(1.0)

--- a/renderchan/contrib/inkscape.py
+++ b/renderchan/contrib/inkscape.py
@@ -3,6 +3,7 @@
 __author__ = 'scribblemaniac'
 
 from renderchan.module import RenderChanModule
+from renderchan import ui
 import subprocess
 import gzip
 import os
@@ -56,6 +57,6 @@ class RenderChanInkscapeModule(RenderChanModule):
         updateCompletion(comp)
 
         commandline=[self.conf['binary'], "--file=" + filename, "--without-gui", "--export-width=" + extraParams["width"], "--export-height=" + extraParams["height"], "--export-%s=%s" % (format, outputPath)]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         updateCompletion(1.0)

--- a/renderchan/contrib/krita.py
+++ b/renderchan/contrib/krita.py
@@ -10,6 +10,7 @@ import locale
 from zipfile import ZipFile
 from xml.etree import ElementTree
 from renderchan.utils import which
+from renderchan import ui
 
 class RenderChanKritaModule(RenderChanModule):
     def __init__(self):
@@ -34,13 +35,13 @@ class RenderChanKritaModule(RenderChanModule):
     def checkRequirements(self):
         if which(self.conf['binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
-            print("    Please install krita package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
+            ui.info("    Please install krita package.")
             return False
         if which(self.conf['convert_binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['convert_binary']))
-            print("    Please install ImageMagick package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['convert_binary']))
+            ui.info("    Please install ImageMagick package.")
             return False
         self.active=True
 
@@ -68,7 +69,7 @@ class RenderChanKritaModule(RenderChanModule):
 
 
         if rc != 0:
-            print('  Krita command failed (exit code %d)!' % rc)
+            ui.error('Krita command failed (exit code %d)!' % rc)
             self.active = False
 
         return self.active
@@ -135,7 +136,7 @@ class RenderChanKritaModule(RenderChanModule):
                 rc = out.poll()
 
             if rc != 0:
-                print('  Krita command failed (exit code %d)!' % rc)
+                ui.error('Krita command failed (exit code %d)!' % rc)
             else:
                 # Resize result
                 
@@ -153,7 +154,7 @@ class RenderChanKritaModule(RenderChanModule):
                         #print(os.path.join(outputPath, filename))
 
                         commandline = [self.conf['convert_binary'], os.path.join(os.path.dirname(outputPathTmp), filename), "-resize", dimensions, os.path.join(outputPath, filename)]
-                        subprocess.check_call(commandline)
+                        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         # Render single image if Krita reported the file has no animation
         else:
@@ -167,11 +168,11 @@ class RenderChanKritaModule(RenderChanModule):
                 else:
                     #TODO: PNG transperency settings at ~/.kde/share/config/kritarc ? use KDEHOME env ?
                     commandline=[self.conf['binary'], "--export", filename, "--export-filename", outputPathTmp]
-                    subprocess.check_call(commandline)
+                    subprocess.check_call(commandline, **ui.quiet_subprocess())
 
                 dimensions = extraParams["width"]+"x"+extraParams["height"]
                 commandline=[self.conf['convert_binary'], outputPathTmp, "-resize", dimensions, outputPath]
-                subprocess.check_call(commandline)
+                subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         if os.path.exists(os.path.dirname(outputPathTmp)):
             shutil.rmtree(os.path.dirname(outputPathTmp))

--- a/renderchan/contrib/list.py
+++ b/renderchan/contrib/list.py
@@ -2,6 +2,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import is_true_string
+from renderchan import ui
 import subprocess
 import gzip
 import os, sys
@@ -39,12 +40,12 @@ class RenderChanListModule(RenderChanModule):
             else:
                 path=os.path.join(dir,line.strip())
                 if os.path.isdir(path):
-                    print("is dir")
+                    ui.debug("is dir")
                     for root, dirs, files in os.walk(path):
                         for file in files:
                             info["dependencies"].append(os.path.join(root, file))
                 else:
-                    print("is file")
+                    ui.debug("is file")
                     info["dependencies"].append(path)
 
         f.close()
@@ -57,8 +58,6 @@ class RenderChanListModule(RenderChanModule):
         updateCompletion(comp)
 
 
-        print('================================================================')
-        print('WARNING:  No rendering available for lst files yet. Skipping.')
-        print('================================================================')
+        ui.warn('No rendering available for lst files yet. Skipping.')
 
         updateCompletion(1)

--- a/renderchan/contrib/metadata/freesound.py
+++ b/renderchan/contrib/metadata/freesound.py
@@ -5,6 +5,7 @@ from urllib.error import HTTPError
 from urllib.request import urlopen, Request
 from html.parser import HTMLParser
 from renderchan.metadata import RenderChanMetadata
+from renderchan import ui
 
 class MyHTMLParser(HTMLParser):
     def __init__(self):
@@ -28,7 +29,7 @@ class MyHTMLParser(HTMLParser):
                     elif value.startswith("http://creativecommons.org/licenses/sampling+"):
                         self.license = "cc-sampling+"
                     else:
-                        print("Error: Unknown license - %s" % value)
+                        ui.error("Unknown license - %s" % value)
 
     def feed(self, data):
         HTMLParser.feed(self, str(data))
@@ -54,7 +55,7 @@ def parse(filename):
 
     if True:
         url = "http://www.freesound.org/people/%s/sounds/%s/" % (user, sound_id)
-        print("Fetching data from %s ..." % url)
+        ui.info("Fetching data from %s ..." % url)
         error = None
         req = Request(url)
         try:
@@ -65,7 +66,7 @@ def parse(filename):
     if error!=None:
         user = user_alt
         url = "http://www.freesound.org/people/%s/sounds/%s/" % (user, sound_id)
-        print("Fetching data from %s ..." % url)
+        ui.info("Fetching data from %s ..." % url)
         error = None
         req = Request(url)
         try:
@@ -76,7 +77,7 @@ def parse(filename):
     if error!=None:
         user = user_alt2
         url = "http://www.freesound.org/people/%s/sounds/%s/" % (user, sound_id)
-        print("Fetching data from %s ..." % url)
+        ui.info("Fetching data from %s ..." % url)
         error = None
         req = Request(url)
         try:
@@ -88,7 +89,7 @@ def parse(filename):
     if error!=None:
         user = user_alt3
         url = "http://www.freesound.org/people/%s/sounds/%s/" % (user, sound_id)
-        print("Fetching data from %s ..." % url)
+        ui.info("Fetching data from %s ..." % url)
         error = None
         req = Request(url)
         try:
@@ -99,14 +100,14 @@ def parse(filename):
     if error!=None:
         user = user_alt4
         url = "http://www.freesound.org/people/%s/sounds/%s/" % (user, sound_id)
-        print("Fetching data from %s ..." % url)
+        ui.info("Fetching data from %s ..." % url)
         error = None
         req = Request(url)
         try:
             f = urlopen(req)
         except HTTPError as e:
             error = e.code
-            print("ERROR: Cannot fetch information for %s" % filename)
+            ui.error("Cannot fetch information for %s" % filename)
 
 
     if error==None:
@@ -123,7 +124,7 @@ def parse(filename):
             metadata.license=parser.license
             metadata.sources=['freesound']
         except:
-            print("ERROR: Error parsing data from freesound! Looks like this sound was deleted...")
+            ui.error("Error parsing data from freesound! Looks like this sound was deleted...")
             metadata.authors.append("%s ( %s ) [DELETED!]" % (user, artist_url))
             metadata.title = basename
             metadata.license = "DELETED"

--- a/renderchan/contrib/mp3.py
+++ b/renderchan/contrib/mp3.py
@@ -4,6 +4,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import which
+from renderchan import ui
 import subprocess
 import os
 import re
@@ -25,13 +26,13 @@ class RenderChanMp3Module(RenderChanModule):
     def checkRequirements(self):
         if which(self.conf['binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
-            print("    Please install mpg123 package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
+            ui.info("    Please install mpg123 package.")
             return False
         if which(self.conf['sox_binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
-            print("    Please install sox package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
+            ui.info("    Please install sox package.")
             return False
         self.active=True
         return True
@@ -47,10 +48,10 @@ class RenderChanMp3Module(RenderChanModule):
         # TODO: Progress callback
 
         commandline=[self.conf['binary'], "-w", tmpfile, filename]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         commandline=[self.conf['sox_binary'], tmpfile, outputPath, "rate", "-v", extraParams["audio_rate"]]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         os.remove(tmpfile)
 

--- a/renderchan/contrib/nuke.py
+++ b/renderchan/contrib/nuke.py
@@ -1,6 +1,7 @@
 __author__ = '036006'
 
 from renderchan.module import RenderChanModule
+from renderchan import ui
 import subprocess
 import os, sys
 import re
@@ -191,7 +192,7 @@ class RenderChanNukeModule(RenderChanModule):
             with open(filename, 'r', encoding='utf-8', errors='replace') as f:
                 content = f.read()
         except IOError as e:
-            print("Error reading Nuke script %s: %s" % (filename, str(e)))
+            ui.error("Error reading Nuke script %s: %s" % (filename, str(e)))
             return info
         
         dirName = os.path.dirname(filename)
@@ -225,7 +226,7 @@ class RenderChanNukeModule(RenderChanModule):
         if startFrame is not None and endFrame is not None:
             info["startFrame"] = startFrame
             info["endFrame"] = endFrame
-            print("    Nuke script frame range (FrameRange node): %d to %d" % (startFrame, endFrame))
+            ui.info("    Nuke script frame range (FrameRange node): %d to %d" % (startFrame, endFrame))
         
         # Parse Root node for frame range
         if startFrame is None or endFrame is None:
@@ -236,11 +237,11 @@ class RenderChanNukeModule(RenderChanModule):
                 if endFrameMatch:
                     info["startFrame"] = 1
                     info["endFrame"] = int(endFrameMatch.group(1).strip())
-                    print("    Nuke script frame range (Root node): %d to %d" % (info["startFrame"], info["endFrame"]))
+                    ui.info("    Nuke script frame range (Root node): %d to %d" % (info["startFrame"], info["endFrame"]))
 
         # Parse Read nodes for dependencies
         readMatches = list(readNodePattern.finditer(content))
-        print("    Found %d Read nodes" % len(readMatches))
+        ui.info("    Found %d Read nodes" % len(readMatches))
 
         for readMatch in readMatches:
             readContent = self._extract_node_content(content, readMatch.end())
@@ -350,12 +351,12 @@ class RenderChanNukeModule(RenderChanModule):
                 "studio": ["--studio"],
             }
             if mode not in mode_flags:
-                print("Unknown Nuke mode '%s', falling back to 'nukex'" % mode)
+                ui.warn("Unknown Nuke mode '%s', falling back to 'nukex'" % mode)
                 mode = "nukex"
 
             commandline = [self.conf['binary']]
             commandline.extend(mode_flags[mode])
-            print("Selected Nuke mode: %s" % mode)
+            ui.info("Selected Nuke mode: %s" % mode)
             
             # Choose execution mode:
             # -t = terminal mode (requires render license)
@@ -369,17 +370,17 @@ class RenderChanNukeModule(RenderChanModule):
             if extraParams.get("disable_gpu", "0") != "1" and os.environ.get("NUKE_DISABLE_GPU") != "1":
                 commandline.append("--gpu")
             else:
-                print("================== FORCE DISABLE GPU =====================")
+                ui.info("================== FORCE DISABLE GPU =====================")
             
             # Execute script and exit
             commandline.append("-x")
             # Execute the Python script
             commandline.append(renderScript)
             
-            print('====================================================')
-            print('  Nuke Render Command:')
-            print('  ' + ' '.join(commandline))
-            print('====================================================')
+            ui.info('====================================================')
+            ui.info('  Nuke Render Command:')
+            ui.info('  ' + ' '.join(commandline))
+            ui.info('====================================================')
             
             env = os.environ.copy()
             env["PYTHONPATH"] = ""
@@ -409,7 +410,7 @@ class RenderChanNukeModule(RenderChanModule):
                 if 'no active write operators' in lineLower or 'total render time' in lineLower:
                     continue
                 
-                print(line, end='')
+                ui.info(line.rstrip())
                 sys.stdout.flush()
                 
                 # Parse progress
@@ -435,17 +436,17 @@ class RenderChanNukeModule(RenderChanModule):
                 
                 rc = out.poll()
             
-            print('====================================================')
+            ui.info('====================================================')
             if rc == 0 or framesWritten:
-                print('  Nuke render completed successfully')
+                ui.info('  Nuke render completed successfully')
             else:
-                print('  Nuke command returns with code %d' % rc)
-            print('====================================================')
+                ui.info('  Nuke command returns with code %d' % rc)
+            ui.info('====================================================')
             
             # Nuke returns code 1 with "no active Write operators" warning even after successful render
             # If we successfully wrote frames, ignore this error
             if rc != 0 and not framesWritten:
-                print('  Nuke command failed...')
+                ui.error('Nuke command failed...')
                 raise Exception('Nuke render failed with exit code %d' % rc)
             
             updateCompletion(1.0)

--- a/renderchan/contrib/olive.py
+++ b/renderchan/contrib/olive.py
@@ -1,6 +1,7 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
+from renderchan import ui
 import subprocess
 import os, sys
 from distutils.version import StrictVersion
@@ -40,13 +41,13 @@ class RenderChanOliveModule(RenderChanModule):
                     # Get the version from stdout. An example of the output: "0.2.0-19eabf28\n"
                     self.version = line.rstrip().split("-")[0]
                     self.version = StrictVersion(self.version)
-                    print("WARNING: Olive version >= 0.2.0 not supported yet.")
+                    ui.warn("Olive version >= 0.2.0 not supported yet.")
                     self.active = False
             else:
                 self.active = False
 
             if self.active == False:
-                print("WARNING: Failed to initialize Olive module.")
+                ui.warn("Failed to initialize Olive module.")
 
         return self.active
 
@@ -110,8 +111,6 @@ class RenderChanOliveModule(RenderChanModule):
     def render(self, filename, outputPath, startFrame, endFrame, format, updateCompletion, extraParams={}):
 
         #if self.version < StrictVersion('0.2.0'):
-            print()
-            print("ERROR: Commandline rendering not implemented for Olive. Aborting.", file=sys.stderr)
-            print()
+            ui.error("Commandline rendering not implemented for Olive. Aborting.", stderr=True)
             exit(1)
 

--- a/renderchan/contrib/opentoonz.py
+++ b/renderchan/contrib/opentoonz.py
@@ -4,6 +4,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import which
+from renderchan import ui
 import subprocess
 import os
 import random
@@ -48,12 +49,12 @@ class RenderChanOpentoonzModule(RenderChanModule):
         os.chdir(os.path.dirname(self.conf['binary']))
         
         commandline=[self.conf['binary'], filename, "-o", os.path.join(img_outputPath, "image."+img_format), "-nthreads", extraParams['nthreads'], "-step", extraParams['step'], "-shrink", extraParams['shrink'], "-multimedia", extraParams['multimedia']]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
         
         if format == "avi":
             #TODO: Detect frame rate!
             commandline=[self.findBinary("ffmpeg"), "-r", "24", "-f", "image2", "-i", os.path.join(img_outputPath, "image.%04d."+img_format), "-c:v", "libx264", outputPath]
-            subprocess.check_call(commandline)
+            subprocess.check_call(commandline, **ui.quiet_subprocess())
             shutil.rmtree(img_outputPath)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/pencil2d.py
+++ b/renderchan/contrib/pencil2d.py
@@ -4,6 +4,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import is_true_string
+from renderchan import ui
 from distutils.version import StrictVersion
 import subprocess
 import tempfile
@@ -51,7 +52,7 @@ class RenderChanPencil2dModule(RenderChanModule):
                 self.active = False
 
             if self.active == False:
-                print("WARNING: Failed to initialize Pencil2D module. The possible reasons for that could be: missing X connection, or the version of Pencil2D on your system is unsupported (too old?). In latter case please consider to get latest version at https://www.pencil2d.org/.")
+                ui.warn("Failed to initialize Pencil2D module. The possible reasons for that could be: missing X connection, or the version of Pencil2D on your system is unsupported (too old?). In latter case please consider to get latest version at https://www.pencil2d.org/.")
 
         return self.active
 
@@ -109,7 +110,7 @@ class RenderChanPencil2dModule(RenderChanModule):
         else:
             commandline=[self.conf['binary'], filename, "--export-sequence", output]
 
-        print(commandline)
-        subprocess.check_call(commandline)
+        ui.info(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         updateCompletion(1.0)

--- a/renderchan/contrib/synfig.py
+++ b/renderchan/contrib/synfig.py
@@ -2,6 +2,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import is_true_string
+from renderchan import ui
 import subprocess
 import gzip
 import os, sys
@@ -170,8 +171,9 @@ class RenderChanSynfigModule(RenderChanModule):
                 if rc is not None:
                     break
             #print(line, end=' ')
-            sys.stdout.buffer.write(line.encode(locale.getpreferredencoding(), errors='replace'))
-            sys.stdout.flush()
+            if ui.is_verbose():
+                sys.stdout.buffer.write(line.encode(locale.getpreferredencoding(), errors='replace'))
+                sys.stdout.flush()
             fn = frameNumberPattern.search(line)
             if fn:
                 currentFrame = float(fn.group(1).strip())
@@ -179,13 +181,13 @@ class RenderChanSynfigModule(RenderChanModule):
                 updateCompletion(comp + fc)
             rc = out.poll()
 
-        print('====================================================')
-        print('  Synfig command returns with code %d' % rc)
-        print('====================================================')
+        ui.info('====================================================')
+        ui.info('  Synfig command returns with code %d' % rc)
+        ui.info('====================================================')
         if rc != 0:
             if os.name == 'nt' and rc == -1073741819:
                 pass
             else:
-                print('  Synfig command failed...')
+                ui.error('Synfig command failed...')
                 raise Exception('  Synfig command failed...')
         updateCompletion(1)

--- a/renderchan/contrib/synfig.py
+++ b/renderchan/contrib/synfig.py
@@ -94,7 +94,7 @@ class RenderChanSynfigModule(RenderChanModule):
         dirname=os.path.dirname(filename)
         for i,val in enumerate(info["dependencies"]):
             # Decode unicode characters
-            info["dependencies"][i]=re.sub("&#x([a-zA-Z0-9]+)(;|(?=\s))", _decode_callback, info["dependencies"][i])
+            info["dependencies"][i]=re.sub(r"&#x([a-zA-Z0-9]+)(;|(?=\s))", _decode_callback, info["dependencies"][i])
             if info["dependencies"][i][0]=="#":
                 info["dependencies"][i]="images/"+info["dependencies"][i][1:]
             info["dependencies"][i]=info["dependencies"][i].replace('%20',' ')

--- a/renderchan/contrib/vorbis.py
+++ b/renderchan/contrib/vorbis.py
@@ -4,6 +4,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
 from renderchan.utils import which
+from renderchan import ui
 import subprocess
 import os
 import random
@@ -24,13 +25,13 @@ class RenderChanVorbisModule(RenderChanModule):
     def checkRequirements(self):
         if which(self.conf['binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['binary']))
-            print("    Please install vorbis-tools package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['binary']))
+            ui.info("    Please install vorbis-tools package.")
             return False
         if which(self.conf['sox_binary']) == None:
             self.active=False
-            print("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
-            print("    Please install sox package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
+            ui.info("    Please install sox package.")
             return False
         self.active=True
         return True
@@ -46,10 +47,10 @@ class RenderChanVorbisModule(RenderChanModule):
         # TODO: Progress callback
 
         commandline=[self.conf['binary'], filename, "-o",tmpfile]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         commandline=[self.conf['sox_binary'], tmpfile, outputPath, "rate", "-v", extraParams["audio_rate"]]
-        subprocess.check_call(commandline)
+        subprocess.check_call(commandline, **ui.quiet_subprocess())
 
         os.remove(tmpfile)
 

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -1177,10 +1177,6 @@ class RenderChan():
                 if not uptodate:
 
                     ui.intro("Merging %s to .%s" % (os.path.basename(taskfile.getPath()), format))
-                    # For the mov-via-png workaround the block title already shows the final
-                    # format, and profile_output is the intermediate png path - skip the line
-                    if not ui.is_verbose() and not (format=="mov" and not module_supports_direct_mov):
-                        ui.notice("Merging: %s" % os.path.relpath(profile_output, taskfile.project.getProfilePath()))
 
                     if taskfile.getPacketSize() > 0:
                         if os.path.exists(profile_output_list):
@@ -1411,8 +1407,6 @@ class RenderChan():
         
         if not uptodate:
             ui.intro("Merging %s to .%s (stereo)" % (os.path.basename(taskfile.getPath()), format))
-            if not ui.is_verbose():
-                ui.notice("Merging: %s" % os.path.relpath(output, taskfile.project.path))
             if mode[0:1]=='v':
                 self.run_ffmpeg_progress(
                         ["ffmpeg", "-y", "-i", input_left, "-i", input_right,

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -14,6 +14,8 @@ from renderchan.utils import which
 from renderchan.utils import is_true_string
 from renderchan import ui
 import os, time
+import re
+import tempfile
 import shutil
 import subprocess
 import zipfile
@@ -922,6 +924,28 @@ class RenderChan():
 
         taskfile.pending=False
 
+    def run_ffmpeg_progress(self, cmd, total_frames, phase="Encoding"):
+        if ui.is_verbose():
+            subprocess.check_call(cmd)
+            return
+        cmd = cmd[:1] + ["-nostats", "-progress", "pipe:1"] + cmd[1:]
+        errlog = tempfile.TemporaryFile()
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=errlog)
+        frame_re = re.compile(r"frame=\s*(\d+)")
+        for line in proc.stdout:
+            m = frame_re.match(line.decode("utf-8", errors="replace").strip())
+            if m and total_frames > 0:
+                ui.progress(phase, min(int(m.group(1)), total_frames), total_frames)
+        rc = proc.wait()
+        if rc != 0:
+            errlog.seek(0)
+            tail = errlog.read().decode("utf-8", errors="replace").splitlines()
+            errlog.close()
+            for line in tail[-10:]:
+                ui.error(line)
+            raise subprocess.CalledProcessError(rc, cmd)
+        errlog.close()
+
     def job_render(self, taskfile, format, updateCompletion, start=None, end=None, compare_time=None):
         """
 
@@ -1010,6 +1034,7 @@ class RenderChan():
         try:
 
             params = taskfile.getParams(self.force_proxy)
+            total_frames = taskfile.getEndFrame()-taskfile.getStartFrame()+1
 
             suffix_list = [""]
             if "extract_alpha" in params and is_true_string(params["extract_alpha"]):
@@ -1031,8 +1056,8 @@ class RenderChan():
 
                 # We need to merge the rendered files into single one
 
-                ui.progress("Merging")
-                ui.notice("Merging: %s" % profile_output)
+                if ui.is_verbose():
+                    ui.notice("Merging: %s" % profile_output)
 
                 # But first let's check if we really need to do that
                 uptodate = False
@@ -1050,6 +1075,12 @@ class RenderChan():
                             os.remove(profile_output + ".done")
 
                 if not uptodate:
+
+                    ui.intro("Merging %s to .%s" % (os.path.basename(taskfile.getPath()), format))
+                    # For the mov-via-png workaround the block title already shows the final
+                    # format, and profile_output is the intermediate png path - skip the line
+                    if not ui.is_verbose() and not (format=="mov" and not module_supports_direct_mov):
+                        ui.notice("Merging: %s" % os.path.relpath(profile_output, taskfile.project.getProfilePath()))
 
                     if taskfile.getPacketSize() > 0:
                         if os.path.exists(profile_output_list):
@@ -1073,11 +1104,16 @@ class RenderChan():
                                 if len(segments)==1:
                                     os.rename(segments[0], profile_output)
                                 else:
+                                    ui.progress("Concatenating")
                                     subprocess.check_call(
-                                        [self.ffmpeg_binary, "-y", "-safe", "0", "-f", "concat", "-i", profile_output_list, "-c", "copy", profile_output])
+                                        [self.ffmpeg_binary, "-y", "-safe", "0", "-f", "concat", "-i", profile_output_list, "-c", "copy", profile_output],
+                                        **ui.quiet_subprocess())
                             elif format=="mov":
                                 num=0
                                 errors = []
+                                total_png = 0
+                                for line in segments:
+                                    total_png += len([f for f in os.listdir(line) if f.lower().endswith('.png')])
                                 for line in segments:
                                     src_dir=line
                                     dst_dir=profile_output
@@ -1099,6 +1135,7 @@ class RenderChan():
                                         except shutil.Error as err:
                                             errors.extend(err.args[0])
                                         num=num+1
+                                        ui.progress("Linking frames", num, total_png)
                                 if errors:
                                     raise shutil.Error(errors)
 
@@ -1124,7 +1161,7 @@ class RenderChan():
                                 ffmpeg_cmd.append("yuv422p10le")
                                 profile_output_mov = os.path.splitext( taskfile.getProfileRenderPath() )[0] + suffix + "." + format
                                 ffmpeg_cmd.append(profile_output_mov)
-                                subprocess.check_call(ffmpeg_cmd)
+                                self.run_ffmpeg_progress(ffmpeg_cmd, total_frames)
                                 shutil.rmtree(profile_output, ignore_errors=True)
                                 profile_output=profile_output_mov
                             else:
@@ -1132,9 +1169,10 @@ class RenderChan():
                                     os.rename(segments[0], profile_output)
                                 else:
                                     # Merge all sequences into single directory
-                                    for line in segments:
+                                    for i, line in enumerate(segments):
                                         ui.info(line)
                                         copytree(line, profile_output, hardlinks=True)
+                                        ui.progress("Copying segments", i+1, len(segments))
 
                             os.remove(profile_output_list)
                             for line in segments:
@@ -1179,7 +1217,7 @@ class RenderChan():
                                 ffmpeg_cmd.append("yuv422p10le")
                                 profile_output_mov = os.path.splitext( taskfile.getProfileRenderPath() )[0] + suffix + "." + format
                                 ffmpeg_cmd.append(profile_output_mov)
-                                subprocess.check_call(ffmpeg_cmd)
+                                self.run_ffmpeg_progress(ffmpeg_cmd, total_frames)
                                 profile_output=profile_output_mov
                             else:
                                 os.rename(segment, profile_output)
@@ -1187,6 +1225,8 @@ class RenderChan():
                         else:
                                 ui.error("Not all segments were rendered. Aborting.", stderr=True)
                                 sys.exit(1)
+
+                    ui.outro("done")
 
                 # Add LST file
                 if format in RenderChanModule.imageExtensions and os.path.isdir(profile_output):
@@ -1228,6 +1268,7 @@ class RenderChan():
 
     def job_merge_stereo(self, taskfile, mode, format="mp4"):
 
+        total_frames = taskfile.getEndFrame()-taskfile.getStartFrame()+1
         ui.progress_context("%s to .%s (stereo)" % (os.path.basename(taskfile.getPath()), format))
 
         output = os.path.splitext(taskfile.getRenderPath())[0]+"-stereo-%s."+format
@@ -1247,8 +1288,8 @@ class RenderChan():
         else:
             output %= mode[0:1]
 
-        ui.progress("Merging")
-        ui.notice("Merging: %s" % output)
+        if ui.is_verbose():
+            ui.notice("Merging: %s" % output)
 
         # But first let's check if we really need to do that
         uptodate = False
@@ -1269,23 +1310,27 @@ class RenderChan():
                     os.remove(output + ".done")
         
         if not uptodate:
+            ui.intro("Merging %s to .%s (stereo)" % (os.path.basename(taskfile.getPath()), format))
+            if not ui.is_verbose():
+                ui.notice("Merging: %s" % os.path.relpath(output, taskfile.project.path))
             if mode[0:1]=='v':
-                subprocess.check_call(
+                self.run_ffmpeg_progress(
                         ["ffmpeg", "-y", "-i", input_left, "-i", input_right,
                          "-filter_complex", "[0:v]setpts=PTS-STARTPTS, pad=iw:ih*2[bg]; [1:v]setpts=PTS-STARTPTS[fg]; [bg][fg]overlay=0:h",
                          "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "1",
                          "-c:a", "aac", "-qscale:a", "0",
                          "-f", "mp4",
-                         output])
+                         output], total_frames)
             else:
-                subprocess.check_call(
+                self.run_ffmpeg_progress(
                         ["ffmpeg", "-y", "-i", input_left, "-i", input_right,
                          "-filter_complex", "[0:v]setpts=PTS-STARTPTS, pad=iw*2:ih[bg]; [1:v]setpts=PTS-STARTPTS[fg]; [bg][fg]overlay=w",
                          "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "1",
                          "-c:a", "aac", "-qscale:a", "0",
                          "-f", "mp4",
-                         output])
+                         output], total_frames)
             touch(output + ".done", os.path.getmtime(output))
+            ui.outro("done")
         else:
             ui.info("  This chunk is already merged. Skipping.")
 

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -82,15 +82,9 @@ class RenderChan():
 
     def __del__(self):
         if self.renderfarm_engine == "":
-            t = time.time()-self.start_time
-            hours = int(t/3600)
-            t = t - hours*3600
-            minutes = int(t/60)
-            t = t - minutes*60
-            seconds = int(t)
             ui.blank()
             ui.blank()
-            ui.info("Execution time: %02d:%02d:%02d " % ( hours, minutes, seconds ))
+            ui.info("Execution time: %s " % ui.format_duration(time.time()-self.start_time))
             ui.blank()
 
     def setHost(self, host):

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -240,7 +240,9 @@ class RenderChan():
                 # before any rendering starts. Analysis is cached, so this costs almost nothing.
                 self._counting_deps = True
                 self._counted_deps = set()
-                self._missing_deps = []
+                self._dep_edges = []
+                self._dep_edge_set = set()
+                self._missing_abspaths = set()
                 # Warnings are muted here: the real pass below will show them once
                 ui.set_muted(True)
                 try:
@@ -250,16 +252,41 @@ class RenderChan():
                 self._counting_deps = False
                 ui.progress_stop()
                 ui.progress_start()  # restart for the rendering phases
-                if self._missing_deps:
+                if self._missing_abspaths:
+                    adjacency = {}
+                    for parent, child in self._dep_edges:
+                        adjacency.setdefault(parent, []).append(child)
+                    root_path = taskfile.getPath()
+                    project_path = taskfile.project.path if taskfile.project else None
+                    has_missing_cache = {}
+
+                    def has_missing(path, seeing=frozenset()):
+                        if path in self._missing_abspaths:
+                            return True
+                        if path in has_missing_cache:
+                            return has_missing_cache[path]
+                        if path in seeing:
+                            return False
+                        result = any(has_missing(c, seeing | {path}) for c in adjacency.get(path, []))
+                        has_missing_cache[path] = result
+                        return result
+
+                    def disp(path):
+                        return os.path.relpath(path, project_path) if project_path else path
+
+                    def print_node(path):
+                        ui.intro(disp(path), warn=True)
+                        own = [c for c in adjacency.get(path, []) if c in self._missing_abspaths]
+                        for d, text in ui.path_tree_lines([disp(c) for c in own]):
+                            ui.log_line("  " * d + text)
+                        for c in adjacency.get(path, []):
+                            if c not in self._missing_abspaths and has_missing(c):
+                                print_node(c)
+                        ui.section_end()
+
                     ui.intro("Missing dependencies")
-                    parents = {}
-                    for parent, dep in self._missing_deps:
-                        parents.setdefault(parent, []).append(dep)
-                    for parent, deps in parents.items():
-                        ui.log_warn(parent)
-                        for line in ui.compress_paths(deps):
-                            ui.log_line("- " + line)
-                    ui.outro("%d missing" % len(self._missing_deps))
+                    print_node(root_path)
+                    ui.outro("%d missing" % len(self._missing_abspaths))
 
             if stereo in ("vertical","v","vertical-cross","vc","horizontal","h","horizontal-cross","hc"):
 
@@ -783,6 +810,15 @@ class RenderChan():
             else:
                 parsed_deps = None
 
+            def record_edge(dependency, raw_path):
+                if parsed_deps is not None and raw_path in parsed_deps:
+                    # Link to the source taskfile: for render dependencies the loop
+                    # path is the rendered output, while the tree is built from sources
+                    edge = (taskfile.getPath(), dependency.getPath())
+                    if edge not in self._dep_edge_set:
+                        self._dep_edge_set.add(edge)
+                        self._dep_edges.append(edge)
+
             for path in deps:
                 path = os.path.abspath(path)
                 if parsed_deps is not None and path in parsed_deps and path not in self._counted_deps:
@@ -794,8 +830,10 @@ class RenderChan():
                         # Avoid circular dependencies
                         ui.warn("Circular dependency detected for %s. Skipping." % (path))
                         continue
+                    record_edge(dependency, path)
                 else:
                     dependency = RenderChanFile(path, self.modules, self.projects)
+                    record_edge(dependency, path)
                     if not os.path.exists(dependency.getPath()):
                         if self.recreateMissing and dependency.projectPath!='':
                             # Let's look if we have a placeholder template
@@ -812,11 +850,7 @@ class RenderChan():
                         else:
                             ui.info("   Skipping file %s..." % path)
                         if not os.path.exists(dependency.getPath()) and getattr(self, '_counting_deps', False):
-                            pair = (
-                                os.path.relpath(taskfile.getPath(), taskfile.project.path) if taskfile.project else taskfile.getPath(),
-                                os.path.relpath(path, taskfile.project.path) if taskfile.project else path)
-                            if pair not in self._missing_deps:
-                                self._missing_deps.append(pair)
+                            self._missing_abspaths.add(path)
                         continue
                     self.loadedFiles[dependency.getPath()]=dependency
                     if dependency.project!=None and dependency.module!=None:

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -176,7 +176,7 @@ class RenderChan():
 
             ui.blank()
             for file in self.trackedFiles.values():
-                print("File: "+file["source"])
+                ui.notice("File: " + file["source"])
             ui.blank()
 
             # Close cache
@@ -213,7 +213,7 @@ class RenderChan():
                     myzip.write(c, c[len(commonpath)+1:])
 
 
-            print("Written "+os.path.join(os.getcwd(),zipname)+".")
+            ui.notice("Written " + os.path.join(os.getcwd(), zipname) + ".")
             ui.blank()
 
             # Close cache

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -170,6 +170,7 @@ class RenderChan():
 
         elif self.action =="pack":
 
+            ui.progress_context(os.path.basename(filename))
             self.addToGraph(taskfile, dependenciesOnly, allocateOnly)
 
             list = []
@@ -192,6 +193,7 @@ class RenderChan():
 
             with zipfile.ZipFile(zipname, 'x') as myzip:
                 for i,c in enumerate(list):
+                    ui.progress("Packing", i, len(list))
                     ui.info("Zipping file: "+c)
                     myzip.write(c, c[len(commonpath)+1:])
 
@@ -204,6 +206,8 @@ class RenderChan():
                 self.projects.list[path].cache.close()
 
         elif self.action =="render":
+
+            ui.progress_start()
 
             if self.renderfarm_engine=="afanasy":
                 if not os.path.exists(os.path.join(self.cgru_location,"afanasy")):
@@ -565,14 +569,17 @@ class RenderChan():
                 # Check if module can render mov directly (like Nuke) or needs png+ffmpeg workaround
                 module_supports_direct_mov = "mov" in taskfile.module.getOutputFormats()
 
+                chunk_format = taskfile.getFormat()
+                if chunk_format=="mov" and not module_supports_direct_mov:
+                    chunk_format = "png"
+                ui.progress_context("%s to .%s (%s)" % (os.path.basename(taskfile.getPath()), chunk_format, taskfile.module.getName()))
+
                 for range in segments:
                     start=range[0]
                     end=range[1]
-                    format=taskfile.getFormat()
-                    if format=="mov" and not module_supports_direct_mov:
-                        format="png"
-                    self.job_render(taskfile, format, self.updateCompletion, start, end, compare_time)
+                    self.job_render(taskfile, chunk_format, self.updateCompletion, start, end, compare_time)
 
+                ui.progress_context("%s to .%s" % (os.path.basename(taskfile.getPath()), taskfile.getFormat()))
                 self.job_merge(taskfile, taskfile.getFormat(), taskfile.project.getConfig("stereo"), compare_time)
 
             elif self.renderfarm_engine=="afanasy":
@@ -874,7 +881,9 @@ class RenderChan():
         return (isDirty, list(tasklist), maxTime)
 
     def updateCompletion(self, value):
+        # verbose: legacy "Rendering: %" line; quiet: shimmer bar (each is a no-op in the other mode)
         ui.info("Rendering: %s" % (value*100))
+        ui.progress("Rendering", value*100, 100)
 
     def __not_used__syncProfileData(self, renderpath):
 
@@ -1022,6 +1031,7 @@ class RenderChan():
 
                 # We need to merge the rendered files into single one
 
+                ui.progress("Merging")
                 ui.notice("Merging: %s" % profile_output)
 
                 # But first let's check if we really need to do that
@@ -1218,6 +1228,8 @@ class RenderChan():
 
     def job_merge_stereo(self, taskfile, mode, format="mp4"):
 
+        ui.progress_context("%s to .%s (stereo)" % (os.path.basename(taskfile.getPath()), format))
+
         output = os.path.splitext(taskfile.getRenderPath())[0]+"-stereo-%s."+format
 
         prev_mode = self.projects.stereo
@@ -1235,6 +1247,7 @@ class RenderChan():
         else:
             output %= mode[0:1]
 
+        ui.progress("Merging")
         ui.notice("Merging: %s" % output)
 
         # But first let's check if we really need to do that

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -240,10 +240,26 @@ class RenderChan():
                 # before any rendering starts. Analysis is cached, so this costs almost nothing.
                 self._counting_deps = True
                 self._counted_deps = set()
-                self.parseDirectDependency(taskfile, None, True, self.force)
+                self._missing_deps = []
+                # Warnings are muted here: the real pass below will show them once
+                ui.set_muted(True)
+                try:
+                    self.parseDirectDependency(taskfile, None, True, self.force)
+                finally:
+                    ui.set_muted(False)
                 self._counting_deps = False
                 ui.progress_stop()
                 ui.progress_start()  # restart for the rendering phases
+                if self._missing_deps:
+                    ui.intro("Missing dependencies")
+                    parents = {}
+                    for parent, dep in self._missing_deps:
+                        parents.setdefault(parent, []).append(dep)
+                    for parent, deps in parents.items():
+                        ui.log_warn(parent)
+                        for dep in deps:
+                            ui.log_line("- " + dep)
+                    ui.outro("%d missing" % len(self._missing_deps))
 
             if stereo in ("vertical","v","vertical-cross","vc","horizontal","h","horizontal-cross","hc"):
 
@@ -767,11 +783,9 @@ class RenderChan():
 
             for path in deps:
                 path = os.path.abspath(path)
-                new_dep = False
                 if parsed_deps is not None and path in parsed_deps and path not in self._counted_deps:
                     self._counted_deps.add(path)
                     ui.progress_tick("Resolving dependencies")
-                    new_dep = True
                 if path in self.loadedFiles.keys():
                     dependency = self.loadedFiles[path]
                     if dependency.pending:
@@ -795,9 +809,12 @@ class RenderChan():
                                 ui.info("   Skipping file %s..." % path)
                         else:
                             ui.info("   Skipping file %s..." % path)
-                        if not os.path.exists(dependency.getPath()) and getattr(self, '_counting_deps', False) and new_dep:
-                            ui.log_warn("Missing: %s" % (
-                                os.path.relpath(path, taskfile.project.path) if taskfile.project else path))
+                        if not os.path.exists(dependency.getPath()) and getattr(self, '_counting_deps', False):
+                            pair = (
+                                os.path.relpath(taskfile.getPath(), taskfile.project.path) if taskfile.project else taskfile.getPath(),
+                                os.path.relpath(path, taskfile.project.path) if taskfile.project else path)
+                            if pair not in self._missing_deps:
+                                self._missing_deps.append(pair)
                         continue
                     self.loadedFiles[dependency.getPath()]=dependency
                     if dependency.project!=None and dependency.module!=None:

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -233,6 +233,17 @@ class RenderChan():
 
             last_task = None
 
+            if not ui.is_verbose() and self.renderfarm_engine == "" and not (dependenciesOnly or allocateOnly) \
+                    and stereo not in ("vertical","v","vertical-cross","vc","horizontal","h","horizontal-cross","hc"):
+                # Quiet mode: cheap dry-run pass to show the "Resolving dependencies" block
+                # before any rendering starts. Analysis is cached, so this costs almost nothing.
+                self._counting_deps = True
+                self._counted_deps = set()
+                self.parseDirectDependency(taskfile, None, True, self.force)
+                self._counting_deps = False
+                ui.progress_stop()
+                ui.progress_start()  # restart for the rendering phases
+
             if stereo in ("vertical","v","vertical-cross","vc","horizontal","h","horizontal-cross","hc"):
 
                 # Left eye graph
@@ -739,8 +750,20 @@ class RenderChan():
 
             deps = taskfile.getDependencies()
 
+            if getattr(self, '_counting_deps', False):
+                # Only dependencies found by parsing the file itself (module.analyze),
+                # not the *.conf files appended by getDependencies()
+                parsed_deps = set(os.path.abspath(p) for p in taskfile.dependencies)
+            else:
+                parsed_deps = None
+
             for path in deps:
                 path = os.path.abspath(path)
+                new_dep = False
+                if parsed_deps is not None and path in parsed_deps and path not in self._counted_deps:
+                    self._counted_deps.add(path)
+                    ui.progress_tick("Resolving dependencies")
+                    new_dep = True
                 if path in self.loadedFiles.keys():
                     dependency = self.loadedFiles[path]
                     if dependency.pending:
@@ -764,6 +787,9 @@ class RenderChan():
                                 ui.info("   Skipping file %s..." % path)
                         else:
                             ui.info("   Skipping file %s..." % path)
+                        if not os.path.exists(dependency.getPath()) and getattr(self, '_counting_deps', False) and new_dep:
+                            ui.log_warn("Missing: %s" % (
+                                os.path.relpath(path, taskfile.project.path) if taskfile.project else path))
                         continue
                     self.loadedFiles[dependency.getPath()]=dependency
                     if dependency.project!=None and dependency.module!=None:

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -408,6 +408,8 @@ class RenderChan():
             if is_dirty is False and self.renderfarm_engine == "" and not self.force:
                 ui.log_success("%s is up to date" % os.path.basename(filename))
                 ui.info("File is up to date: %s" % filename)
+                ui.blank()
+                ui.rail_blank()
 
         self.trackFileEnd()
 

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -232,6 +232,7 @@ class RenderChan():
                 self.graph = Graph( 'RenderChan graph', poolName="default" )
 
             last_task = None
+            is_dirty = None
 
             if not ui.is_verbose() and self.renderfarm_engine == "" and not (dependenciesOnly or allocateOnly) \
                     and stereo not in ("vertical","v","vertical-cross","vc","horizontal","h","horizontal-cross","hc"):
@@ -301,7 +302,7 @@ class RenderChan():
                     self.setStereoMode("left")
                 elif stereo in ("right","r"):
                     self.setStereoMode("right")
-                self.addToGraph(taskfile, dependenciesOnly, allocateOnly)
+                is_dirty = self.addToGraph(taskfile, dependenciesOnly, allocateOnly)
 
                 last_task = taskfile.taskPost
 
@@ -388,6 +389,10 @@ class RenderChan():
                 # TODO: Render our Graph
                 pass
 
+            if is_dirty is False and self.renderfarm_engine == "" and not self.force:
+                ui.log_success("%s is up to date" % os.path.basename(filename))
+                ui.info("File is up to date: %s" % filename)
+
         self.trackFileEnd()
 
 
@@ -400,6 +405,8 @@ class RenderChan():
         for path in self.loadedFiles.keys():
             self.loadedFiles[path].isDirty=None
         #self.loadedFiles={}
+
+        result = None
 
         # == taskgroups bug / commented ==
         # Prepare taskgroups if we do stereo rendering
@@ -432,10 +439,11 @@ class RenderChan():
 
         else:
 
-            self.parseRenderDependency(taskfile, allocateOnly, self.dry_run, self.force)
+            result = self.parseRenderDependency(taskfile, allocateOnly, self.dry_run, self.force)
 
 
         self.childTask = None
+        return result
 
 
     def trackFileBegin(self, taskfile):

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -653,10 +653,13 @@ class RenderChan():
                     chunk_format = "png"
                 ui.progress_context("%s to .%s (%s)" % (os.path.basename(taskfile.getPath()), chunk_format, taskfile.module.getName()))
 
-                for range in segments:
+                for i, range in enumerate(segments):
                     start=range[0]
                     end=range[1]
-                    self.job_render(taskfile, chunk_format, self.updateCompletion, start, end, compare_time)
+                    # Scale per-segment completion into the overall range,
+                    # so the bar runs 0..100 once, not once per packet
+                    seg_cb = (lambda i=i: lambda v: self.updateCompletion((i + v) / len(segments)))()
+                    self.job_render(taskfile, chunk_format, seg_cb, start, end, compare_time)
 
                 ui.progress_context("%s to .%s" % (os.path.basename(taskfile.getPath()), taskfile.getFormat()))
                 self.job_merge(taskfile, taskfile.getFormat(), taskfile.project.getConfig("stereo"), compare_time)

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -140,6 +140,13 @@ class RenderChan():
 
         """
 
+        if not os.path.exists(filename):
+            display = os.path.relpath(filename)
+            if display.startswith(".."):
+                display = filename
+            ui.error("File not found: %s" % display, stderr=True)
+            return 1
+
         taskfile = RenderChanFile(filename, self.modules, self.projects)
         self.trackFileBegin(taskfile)
 

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -257,8 +257,8 @@ class RenderChan():
                         parents.setdefault(parent, []).append(dep)
                     for parent, deps in parents.items():
                         ui.log_warn(parent)
-                        for dep in deps:
-                            ui.log_line("- " + dep)
+                        for line in ui.compress_paths(deps):
+                            ui.log_line("- " + line)
                     ui.outro("%d missing" % len(self._missing_deps))
 
             if stereo in ("vertical","v","vertical-cross","vc","horizontal","h","horizontal-cross","hc"):

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -158,7 +158,13 @@ class RenderChan():
         if not taskfile.module:
             extension = os.path.splitext(taskfile.getPath())[1]
             if extension:
-                ui.error("The '%s' file type was not recoginized." % extension, stderr=True)
+                ext = extension[1:].lower()
+                unavailable = [m.getName() for m in self.modules.list.values()
+                               if ext in m.getInputFormats() and not m.active]
+                if unavailable:
+                    ui.error("The '%s' file type requires the '%s' module, which was not found." % (extension, unavailable[0]), stderr=True)
+                else:
+                    ui.error("The '%s' file type was not recognized." % extension, stderr=True)
             else:
                 ui.error("The provided file does not have an extension.", stderr=True)
             self.trackFileEnd()

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -12,6 +12,7 @@ from renderchan.utils import touch
 from renderchan.utils import copytree
 from renderchan.utils import which
 from renderchan.utils import is_true_string
+from renderchan import ui
 import os, time
 import shutil
 import subprocess
@@ -29,7 +30,7 @@ class RenderChan():
         self.renderfarm_host = "127.0.0.1"
         self.renderfarm_port = 8004
 
-        print("RenderChan initialized.")
+        ui.info("RenderChan initialized.")
         self.start_time = time.time()
         self.projects = RenderChanProjectManager()
         self.modules = RenderChanModuleManager()
@@ -87,10 +88,10 @@ class RenderChan():
             minutes = int(t/60)
             t = t - minutes*60
             seconds = int(t)
-            print()
-            print()
-            print("Execution time: %02d:%02d:%02d " % ( hours, minutes, seconds ))
-            print()
+            ui.blank()
+            ui.blank()
+            ui.info("Execution time: %02d:%02d:%02d " % ( hours, minutes, seconds ))
+            ui.blank()
 
     def setHost(self, host):
         self.renderfarm_host=host
@@ -147,20 +148,16 @@ class RenderChan():
         self.trackFileBegin(taskfile)
 
         if taskfile.project == None:
-            print(file=sys.stderr)
-            print("ERROR: Can't render a file which is not a part of renderchan project.", file=sys.stderr)
-            print(file=sys.stderr)
+            ui.error("Can't render a file which is not a part of renderchan project.", stderr=True)
             self.trackFileEnd()
             return 1
 
         if not taskfile.module:
-            print(file=sys.stderr)
             extension = os.path.splitext(taskfile.getPath())[1]
             if extension:
-                print("ERROR: The '%s' file type was not recoginized." % extension, file=sys.stderr)
+                ui.error("The '%s' file type was not recoginized." % extension, stderr=True)
             else:
-                print("ERROR: The provided file does not have an extension.", file=sys.stderr)
-            print(file=sys.stderr)
+                ui.error("The provided file does not have an extension.", stderr=True)
             self.trackFileEnd()
             return 1
 
@@ -168,10 +165,10 @@ class RenderChan():
 
             self.addToGraph(taskfile, dependenciesOnly, allocateOnly)
 
-            print()
+            ui.blank()
             for file in self.trackedFiles.values():
                 print("File: "+file["source"])
-            print()
+            ui.blank()
 
             # Close cache
             for path in self.projects.list.keys():
@@ -190,23 +187,23 @@ class RenderChan():
             #    list[i]=c[len(commonpath)+1:]
             #    print(list[i])
 
-            print()
+            ui.blank()
 
             zipname = os.path.basename(taskfile.getPath())+'.zip'
 
             if os.path.exists(os.path.join(os.getcwd(),zipname)):
-                print("ERROR: File "+os.path.join(os.getcwd(),zipname)+" already exists.")
+                ui.error("File "+os.path.join(os.getcwd(),zipname)+" already exists.")
                 sys.exit()
 
 
             with zipfile.ZipFile(zipname, 'x') as myzip:
                 for i,c in enumerate(list):
-                    print("Zipping file: "+c)
+                    ui.info("Zipping file: "+c)
                     myzip.write(c, c[len(commonpath)+1:])
 
 
             print("Written "+os.path.join(os.getcwd(),zipname)+".")
-            print()
+            ui.blank()
 
             # Close cache
             for path in self.projects.list.keys():
@@ -216,7 +213,7 @@ class RenderChan():
 
             if self.renderfarm_engine=="afanasy":
                 if not os.path.exists(os.path.join(self.cgru_location,"afanasy")):
-                    print("ERROR: Cannot render with afanasy, afanasy not found at cgru directory '%s'." % self.cgru_location, file=sys.stderr)
+                    ui.error("Cannot render with afanasy, afanasy not found at cgru directory '%s'." % self.cgru_location, stderr=True)
                     self.trackFileEnd()
                     return 1
 
@@ -416,7 +413,7 @@ class RenderChan():
         elif allocateOnly:
 
             if os.path.exists(taskfile.getRenderPath()):
-                print("File is already allocated.")
+                ui.notice("File is already allocated.")
                 sys.exit(0)
             taskfile.dependencies=[]
             taskfile.endFrame = taskfile.startFrame + 2
@@ -515,7 +512,7 @@ class RenderChan():
             isDirty = True
             compareTime = None
             if os.environ.get('DEBUG'):
-                print("DEBUG: Dirty = 1 (no rendering exists)")
+                ui.debug("DEBUG: Dirty = 1 (no rendering exists)")
         else:
             # Otherwise we have to check against the time of the last rendering
             compareTime = float_trunc(os.path.getmtime(taskfile.getProfileRenderPath()),1)
@@ -745,7 +742,7 @@ class RenderChan():
                     dependency = self.loadedFiles[path]
                     if dependency.pending:
                         # Avoid circular dependencies
-                        print("Warning: Circular dependency detected for %s. Skipping." % (path))
+                        ui.warn("Circular dependency detected for %s. Skipping." % (path))
                         continue
                 else:
                     dependency = RenderChanFile(path, self.modules, self.projects)
@@ -755,15 +752,15 @@ class RenderChan():
                             ext = os.path.splitext(path)[1]
                             placeholder = os.path.join(self.datadir, "missing", "empty" + ext)
                             if os.path.exists(placeholder):
-                                print("   Creating an empty placeholder for %s..." % path)
+                                ui.info("   Creating an empty placeholder for %s..." % path)
                                 mkdirs(os.path.dirname(path))
                                 shutil.copy(placeholder, path)
                                 t = time.mktime(time.strptime('01.01.1981 00:00:00', '%d.%m.%Y %H:%M:%S'))
                                 os.utime(path,(t,t))
                             else:
-                                print("   Skipping file %s..." % path)
+                                ui.info("   Skipping file %s..." % path)
                         else:
-                            print("   Skipping file %s..." % path)
+                            ui.info("   Skipping file %s..." % path)
                         continue
                     self.loadedFiles[dependency.getPath()]=dependency
                     if dependency.project!=None and dependency.module!=None:
@@ -801,17 +798,17 @@ class RenderChan():
                         if compareTime is None:
                             isDirty = True
                             if os.environ.get('DEBUG'):
-                                print("DEBUG: %s:" % taskfile.getPath())
-                                print("DEBUG: Dirty = 1 (no compare time)")
-                                print()
+                                ui.debug("DEBUG: %s:" % taskfile.getPath())
+                                ui.debug("DEBUG: Dirty = 1 (no compare time)")
+                                ui.debug()
                         elif timestamp > compareTime:
                             isDirty = True
                             if os.environ.get('DEBUG'):
-                                print("DEBUG: %s:" % taskfile.getPath())
-                                print("DEBUG: Dirty = 1 (dependency timestamp is higher)")
-                                print("DEBUG:            compareTime     = %f" % (compareTime))
-                                print("DEBUG:            dependency time = %f" % (timestamp))
-                                print()
+                                ui.debug("DEBUG: %s:" % taskfile.getPath())
+                                ui.debug("DEBUG: Dirty = 1 (dependency timestamp is higher)")
+                                ui.debug("DEBUG:            compareTime     = %f" % (compareTime))
+                                ui.debug("DEBUG:            dependency time = %f" % (timestamp))
+                                ui.debug()
                         if timestamp>maxTime:
                             maxTime=timestamp
 
@@ -828,18 +825,18 @@ class RenderChan():
                 timestamp = float_trunc(taskfile.getTime(), 1)
                 if compareTime is None:
                     if os.environ.get('DEBUG'):
-                        print("DEBUG: %s:" % taskfile.getPath())
-                        print("DEBUG: Dirty = 1 (no compare time)")
-                        print()
+                        ui.debug("DEBUG: %s:" % taskfile.getPath())
+                        ui.debug("DEBUG: Dirty = 1 (no compare time)")
+                        ui.debug()
                     isDirty = True
                 elif timestamp > compareTime:
                     isDirty = True
                     if os.environ.get('DEBUG'):
-                        print("DEBUG: %s:" % taskfile.getPath())
-                        print("DEBUG: Dirty = 1 (source timestamp is higher)")
-                        print("DEBUG:            compareTime     = %f" % (compareTime))
-                        print("DEBUG:            source time = %f" % (timestamp))
-                        print()
+                        ui.debug("DEBUG: %s:" % taskfile.getPath())
+                        ui.debug("DEBUG: Dirty = 1 (source timestamp is higher)")
+                        ui.debug("DEBUG:            compareTime     = %f" % (compareTime))
+                        ui.debug("DEBUG:            source time = %f" % (timestamp))
+                        ui.debug()
                 if timestamp>maxTime:
                     maxTime=timestamp
 
@@ -883,7 +880,7 @@ class RenderChan():
         return (isDirty, list(tasklist), maxTime)
 
     def updateCompletion(self, value):
-        print("Rendering: %s" % (value*100))
+        ui.info("Rendering: %s" % (value*100))
 
     def __not_used__syncProfileData(self, renderpath):
 
@@ -891,12 +888,12 @@ class RenderChan():
             taskfile = self.loadedFiles[renderpath]
             if taskfile.pending:
                 # Avoid circular dependencies
-                print("Warning: Circular dependency detected for %s. Skipping." % (renderpath))
+                ui.warn("Circular dependency detected for %s. Skipping." % (renderpath))
                 return
         else:
             taskfile = RenderChanFile(renderpath, self.modules, self.projects)
             if not os.path.exists(taskfile.getPath()):
-                print("   No source file for %s. Skipping." % renderpath)
+                ui.info("   No source file for %s. Skipping." % renderpath)
                 return
             self.loadedFiles[taskfile.getPath()]=taskfile
             taskfile.pending=True  # we need this to avoid circular dependencies
@@ -982,7 +979,7 @@ class RenderChan():
             except:
                 for lock in locks:
                     lock.unlock()
-                print("Unexpected error:", sys.exc_info()[0])
+                ui.error("Unexpected error: %s" % (sys.exc_info()[0],))
                 raise
 
             # Releasing PROJECT LOCK
@@ -990,7 +987,7 @@ class RenderChan():
                 lock.unlock()
 
         else:
-            print("  This chunk is already up to date. Skipping.")
+            ui.info("  This chunk is already up to date. Skipping.")
 
         updateCompletion(1.0)
 
@@ -1031,7 +1028,7 @@ class RenderChan():
 
                 # We need to merge the rendered files into single one
 
-                print("Merging: %s" % profile_output)
+                ui.notice("Merging: %s" % profile_output)
 
                 # But first let's check if we really need to do that
                 uptodate = False
@@ -1062,7 +1059,7 @@ class RenderChan():
                                     segments.append(line)
                                     
                                     if not os.path.exists(line+".done") or not os.path.exists(line):
-                                        print("ERROR: Not all segments were rendered. Aborting.", file=sys.stderr)
+                                        ui.error("Not all segments were rendered. Aborting.", stderr=True)
                                         sys.exit(1)
                             
                             if os.path.isfile(profile_output+".done"):
@@ -1132,7 +1129,7 @@ class RenderChan():
                                 else:
                                     # Merge all sequences into single directory
                                     for line in segments:
-                                        print(line)
+                                        ui.info(line)
                                         copytree(line, profile_output, hardlinks=True)
 
                             os.remove(profile_output_list)
@@ -1145,7 +1142,7 @@ class RenderChan():
                                     os.remove(line+".done")
                             touch(profile_output + ".done", float(compare_time))
                         else:
-                            print("  This chunk is already merged. Skipping.")
+                            ui.info("  This chunk is already merged. Skipping.")
                         #updateCompletion(0.5)
 
                     else:
@@ -1184,7 +1181,7 @@ class RenderChan():
                                 os.rename(segment, profile_output)
                             touch(profile_output + ".done", float(compare_time))
                         else:
-                                print("ERROR: Not all segments were rendered. Aborting.", file=sys.stderr)
+                                ui.error("Not all segments were rendered. Aborting.", stderr=True)
                                 sys.exit(1)
 
                 # Add LST file
@@ -1214,7 +1211,7 @@ class RenderChan():
                 touch(output, float(compare_time))
 
         except Exception as e:
-            print("ERROR: Merge operation failed: %s" % e, file=sys.stderr)
+            ui.error("Merge operation failed: %s" % e, stderr=True)
             for lock in locks:
                 lock.unlock()
             sys.exit(1)
@@ -1244,7 +1241,7 @@ class RenderChan():
         else:
             output %= mode[0:1]
 
-        print("Merging: %s" % output)
+        ui.notice("Merging: %s" % output)
 
         # But first let's check if we really need to do that
         uptodate = False
@@ -1283,7 +1280,7 @@ class RenderChan():
                          output])
             touch(output + ".done", os.path.getmtime(output))
         else:
-            print("  This chunk is already merged. Skipping.")
+            ui.info("  This chunk is already merged. Skipping.")
 
 
     def job_snapshot(self, renderpath, snapshot_dir):
@@ -1295,9 +1292,9 @@ class RenderChan():
         filename = os.path.splitext(os.path.basename(renderpath))[0] + "-" + time_string + os.path.splitext(renderpath)[1]
         snapshot_path = os.path.join(snapshot_dir, filename)
 
-        print()
-        print("Creating snapshot to %s ..." % (filename))
-        print()
+        ui.blank()
+        ui.notice("Creating snapshot to %s ..." % (filename))
+        ui.blank()
 
         if os.path.isdir(snapshot_path):
             try:

--- a/renderchan/file.py
+++ b/renderchan/file.py
@@ -5,6 +5,7 @@ import configparser
 from renderchan.module import RenderChanModule
 from renderchan.utils import float_trunc, ini_wrapper, is_true_string, sanitize_path
 from renderchan.metadata import RenderChanMetadata
+from renderchan import ui
 
 class RenderChanFile():
     def __init__(self, path, modules, projects):
@@ -16,7 +17,7 @@ class RenderChanFile():
         if self.projectPath!='':
             self.project=projects.get(self.projectPath)
         else:
-            print("Warning: File %s doesn't belong to any project." % (path))
+            ui.warn("File %s doesn't belong to any project." % (path))
 
         # Associated tasks
         self.taskPost=None
@@ -55,7 +56,7 @@ class RenderChanFile():
                     output_str=path
                 if len(output_str)>60:
                     output_str="..."+output_str[-60:]
-                print(". Analyzing file: %s" % output_str)
+                ui.info(". Analyzing file: %s" % output_str)
 
                 info=None
                 dependencies=None
@@ -63,7 +64,7 @@ class RenderChanFile():
                     info=self.project.cache.getInfo(self.localPath)
                     dependencies=self.project.cache.getDependencies(self.localPath)
                 if info!=None and dependencies!=None and info["timestamp"]>=self.getTime():
-                    print(". . Cache found")
+                    ui.info(". . Cache found")
                     self.startFrame=int(info["startFrame"])
                     self.endFrame=int(info["endFrame"])
                     for dep in dependencies:
@@ -110,7 +111,7 @@ class RenderChanFile():
                     self.setFormat(ext)
 
             else:
-                print("Warning: No source file found for %s" % path)
+                ui.warn("No source file found for %s" % path)
 
     def _loadConfig(self, filename):
 
@@ -302,13 +303,13 @@ class RenderChanFile():
                     try:
                         proxy_scale = float(params['proxy_scale'])
                     except:
-                        print("WARNING: Wrong value for 'proxy scale' (%s)." % self.getPath())
+                        ui.warn("Wrong value for 'proxy scale' (%s)." % self.getPath())
                         proxy_scale = 1.0
                     width=int(params['width'])
                     height=int(params['height'])
                     if not force_proxy and (((width*proxy_scale) % 1) != 0 or ((height*proxy_scale) % 1) != 0):
-                        print("WARNING: Can't apply 'proxy scale' for file (%s):" % self.getPath())
-                        print("         Dimensions %sx%s give non-integer values when multiplied by factor of %s." % (width, height, proxy_scale))
+                        ui.warn("Can't apply 'proxy scale' for file (%s):" % self.getPath())
+                        ui.warn("         Dimensions %sx%s give non-integer values when multiplied by factor of %s." % (width, height, proxy_scale))
                     else:
                         params['width'] = str(width*proxy_scale)
                         params['height'] = str(height*proxy_scale)
@@ -376,7 +377,7 @@ class RenderChanFile():
             self.project.setFrozen(self.localPath, value)
         else:
             if value:
-                print("ERROR: Cannot freeze file which is not a part of any project.", file=sys.stderr)
+                ui.error("Cannot freeze file which is not a part of any project.", stderr=True)
 
     def getMetadata(self):
         if self.metadata==None:

--- a/renderchan/file.py
+++ b/renderchan/file.py
@@ -17,7 +17,10 @@ class RenderChanFile():
         if self.projectPath!='':
             self.project=projects.get(self.projectPath)
         else:
-            ui.warn("File %s doesn't belong to any project." % (path))
+            # Quiet: missing files are already covered by the "Missing dependencies"
+            # block; warn only for existing files (unique info there)
+            if ui.is_verbose() or os.path.exists(path):
+                ui.warn("File %s doesn't belong to any project." % (path))
 
         # Associated tasks
         self.taskPost=None
@@ -111,7 +114,9 @@ class RenderChanFile():
                     self.setFormat(ext)
 
             else:
-                ui.warn("No source file found for %s" % path)
+                # Quiet: covered by the "Missing dependencies" block
+                if ui.is_verbose():
+                    ui.warn("No source file found for %s" % path)
 
     def _loadConfig(self, filename):
 

--- a/renderchan/httpserver.py
+++ b/renderchan/httpserver.py
@@ -10,6 +10,7 @@ import os.path
 import json
 
 from renderchan.core import RenderChan
+from renderchan import ui
 
 
 class RenderChanHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -99,6 +100,8 @@ def process_args():
 
 def main(datadir, argv):
     args = process_args()
+
+    ui.set_verbose(True)
 
     server = HTTPServer((args.host, args.port), RenderChanHTTPRequestHandler)
     server.renderchan_datadir = datadir

--- a/renderchan/joblauncher.py
+++ b/renderchan/joblauncher.py
@@ -5,6 +5,7 @@ from optparse import OptionParser
 import os
 from renderchan.core import RenderChan
 from renderchan.file import RenderChanFile
+from renderchan import ui
 import sys
 
 
@@ -55,17 +56,20 @@ def process_args():
     if args:
         options.filename=os.path.abspath(args[0])
     else:
-        print("ERROR: Please provide input filename", file=sys.stderr)
+        ui.error("Please provide input filename", stderr=True)
         exit(1)
 
     return options, args
 
 def updateCompletion(value):
-    print("Rendering: %s" % (value*100))
+    ui.info("Rendering: %s" % (value*100))
+    ui.progress("Rendering", value*100, 100)
 
 
 def main(argv):
     options, args = process_args()
+
+    ui.set_verbose(True)
 
     renderchan = RenderChan()
     renderchan.projects.readonly = True
@@ -96,9 +100,9 @@ def main(argv):
         else:
             (isDirty, tasklist, maxTime)=renderchan.parseDirectDependency(taskfile, compare_time)
             if isDirty:
-                print("ERROR: There are unrendered dependencies for this file!", file=sys.stderr)
-                print("       (Project tree changed or job started too early?)", file=sys.stderr)
-                print("       Aborting.", file=sys.stderr)
+                ui.error("There are unrendered dependencies for this file!", stderr=True)
+                ui.error("       (Project tree changed or job started too early?)", stderr=True)
+                ui.error("       Aborting.", stderr=True)
                 exit(1)
 
     if options.action == 'render':
@@ -113,6 +117,6 @@ def main(argv):
             renderchan.job_merge(taskfile, taskfile.getFormat(), renderchan.projects.stereo, compare_time)
     elif options.action == 'snapshot':
         if not options.snapshot_target:
-            print("ERROR: Please specify output filename using --target-dir option.", file=sys.stderr)
+            ui.error("Please specify output filename using --target-dir option.", stderr=True)
         renderchan.job_snapshot(options.filename, os.path.abspath(options.snapshot_target))
 

--- a/renderchan/manager.py
+++ b/renderchan/manager.py
@@ -8,6 +8,7 @@ from renderchan.core import RenderChan
 from renderchan.core import Attribution
 from renderchan.file import RenderChanFile
 from renderchan.project import RenderChanProject
+from renderchan import ui
 
 
 def process_args():
@@ -36,6 +37,8 @@ def process_args():
 
 def main(argv):
     options, args = process_args()
+
+    ui.set_verbose(True)
 
     # Parse frozen parameters
     # The --freeze and --unfreeze options are temporary disabled, because this function should behave differently.

--- a/renderchan/module.py
+++ b/renderchan/module.py
@@ -40,11 +40,16 @@ class RenderChanModuleManager():
     def loadAll(self):
         dir = os.path.dirname(os.path.abspath(__file__))
         modulesdir = os.path.join(dir, "contrib")
-        files = [ f for f in os.listdir(modulesdir) if os.path.isfile(os.path.join(modulesdir,f)) ]
-        for f in files:
+        names = []
+        for f in os.listdir(modulesdir):
             filename, ext = os.path.splitext(f)
-            if ext==".py" and filename!='__init__':
-                self.load(filename)
+            if ext==".py" and filename!='__init__' and os.path.isfile(os.path.join(modulesdir,f)):
+                names.append(filename)
+        ui.progress_start()
+        for i, name in enumerate(names):
+            self.load(name)
+            ui.progress("Loading modules", i+1, len(names))
+        ui.progress_stop()
 
     def get(self, name):
         if name not in self.list:

--- a/renderchan/module.py
+++ b/renderchan/module.py
@@ -2,6 +2,7 @@ __author__ = 'Konstantin Dmitriev'
 
 from importlib import import_module
 from renderchan.utils import which
+from renderchan import ui
 import os, sys
 import inspect
 import configparser
@@ -31,9 +32,9 @@ class RenderChanModuleManager():
 
         module = moduleClass()
         module.loadConfiguration()
-        print("Loading module: " + name + "...")
+        ui.info("Loading module: " + name + "...")
         if not module.checkRequirements():
-            print("Warning: Unable load module - %s." % (name))
+            ui.info("Unable load module - %s." % (name))
         self.list[name]=module
 
     def loadAll(self):
@@ -111,10 +112,10 @@ class RenderChanModule():
     def setConfiguration(self, conf):
         for key,value in list(conf.items()):
             if key not in self.conf:
-                print("Module %s doesn't accept configuration key '%s': No such entry." % (self.__class__.__name__, key))
+                ui.info("Module %s doesn't accept configuration key '%s': No such entry." % (self.__class__.__name__, key))
                 continue
             if not type(self.conf[key]).__name__ == type(conf[key]).__name__:
-                print("Module %s doesn't accept configuration value for key '%s': Wrong type." % (self.__class__.__name__, key))
+                ui.info("Module %s doesn't accept configuration value for key '%s': Wrong type." % (self.__class__.__name__, key))
                 continue
             self.conf[key] = conf[key]
 
@@ -123,8 +124,8 @@ class RenderChanModule():
             binary_path = which(self.conf['binary'])
             if binary_path == None:
                 self.active=False
-                print("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf["binary"]))
-                print("    Please install %s package." % (self.getName()))
+                ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf["binary"]))
+                ui.info("    Please install %s package." % (self.getName()))
             else:
                 # Workaround because some applications (gimp) cannot be executed via symlink
                 self.conf['binary'] = binary_path
@@ -167,8 +168,8 @@ class RenderChanModule():
                 if binary_path:
                     return binary_path
                 else:
-                    print("    Cannot find path to %s package in %s." % (name, path))
-                    print("    Please make sure to install %s and write correct path to %s file." % (name, path))
+                    ui.info("    Cannot find path to %s package in %s." % (name, path))
+                    ui.info("    Please make sure to install %s and write correct path to %s file." % (name, path))
                     return name
         
         binary_suffix=""

--- a/renderchan/module.py
+++ b/renderchan/module.py
@@ -46,9 +46,9 @@ class RenderChanModuleManager():
             if ext==".py" and filename!='__init__' and os.path.isfile(os.path.join(modulesdir,f)):
                 names.append(filename)
         ui.progress_start()
-        for i, name in enumerate(names):
+        for name in names:
             self.load(name)
-            ui.progress("Loading modules", i+1, len(names))
+            ui.progress_tick("Loading modules")
         ui.progress_stop()
 
     def get(self, name):

--- a/renderchan/project.py
+++ b/renderchan/project.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 from renderchan.utils import mkdirs, sync, file_is_older_than, ini_wrapper, LockThread, copytree
 from renderchan.cache import RenderChanCache
+from renderchan import ui
 
 class RenderChanProjectManager():
     def __init__(self):
@@ -137,7 +138,7 @@ class RenderChanProject():
             if self.language == current_language:
                 needCleanup=False
         if needCleanup and os.path.exists(os.path.join(self.path,'render',localedir)):
-            print("The language data is inconsistent in %s. Cleaning..." % os.path.join(self.path,'render',localedir))
+            ui.info("The language data is inconsistent in %s. Cleaning..." % os.path.join(self.path,'render',localedir))
             shutil.rmtree(os.path.join(self.path,'render',localedir))
             if os.path.exists(os.path.join(self.path,localedir)):
                 mkdirs(os.path.join(self.path,'render',localedir))
@@ -159,7 +160,7 @@ class RenderChanProject():
         """
         if self.version==0 and profile!=None:
 
-            print("Warning: Profiles are not supported with old project format. No profile loaded.")
+            ui.warn("Profiles are not supported with old project format. No profile loaded.")
             return False
 
         elif self.version==0:
@@ -183,9 +184,7 @@ class RenderChanProject():
                         break
                     if os.path.realpath(os.path.dirname(realConfigPath)) == os.path.realpath(realConfigPath):
                         # We have reached root directory, no parent config found
-                        print(file=sys.stderr)
-                        print("ERROR: Empty project.conf found, but no non-empty parent project.conf could be located.", file=sys.stderr)
-                        print(file=sys.stderr)
+                        ui.error("Empty project.conf found, but no non-empty parent project.conf could be located.", stderr=True)
                         sys.exit(1)
                     realConfigPath = os.path.dirname(realConfigPath)
                 realConfigPath = os.path.join(realConfigPath,"project.conf")
@@ -201,7 +200,7 @@ class RenderChanProject():
             # sanity check
             for section in config.sections():
                 if "." in section:
-                    print("Warning: Incorrect profile name found (%s) - dots are not allowed." % (section))
+                    ui.warn("Incorrect profile name found (%s) - dots are not allowed." % (section))
 
             if profile==None:
                 if config.has_option("main", "active_profile"):
@@ -394,17 +393,17 @@ class RenderChanProject():
             return False
 
         if language==current_language:
-            print("This language is already active.")
+            ui.notice("This language is already active.")
             return True
 
         if not os.path.exists(localedirpath+"."+language):
             if not create:
-                print("Error: No such language (%s)." % language, file=sys.stderr)
+                ui.error("No such language (%s)." % language, stderr=True)
                 return False
             else:
-                print("Creating new language: %s..." % language)
+                ui.notice("Creating new language: %s..." % language)
                 copytree(localedirpath, localedirpath+"."+language, False, False, ignore_audio)
-                print("   Language %s copied to %s." % (current_language,language))
+                ui.notice("   Language %s copied to %s." % (current_language,language))
             os.remove(os.path.join(localedirpath+"."+language, "lang.conf"))
 
         # do directory switch
@@ -420,7 +419,7 @@ class RenderChanProject():
             mkdirs(os.path.join(self.path,'render',localedir))
             shutil.copy2(os.path.join(localedirpath,'lang.conf'),os.path.join(self.path,'render',localedir,'lang.conf'))
 
-        print("Done.")
+        ui.notice("Done.")
         return True
 
 
@@ -444,7 +443,7 @@ class RenderChanProject():
         msg=""
         while True:
             if msg!="":
-                print(msg)
+                ui.warn(msg)
             msg="The rendertree is locked by other process. Waiting..."
             # Check if we are on correct profile
             need_sync = True
@@ -535,7 +534,7 @@ class RenderChanProject():
                         continue
                 else:
                     # something is wrong, because file is vanished
-                    print("Warning: Something is wrong, since lock file is vanished. Waiting for 5 seconds...")
+                    ui.warn("Something is wrong, since lock file is vanished. Waiting for 5 seconds...")
                     time.sleep(5)
                     continue
 

--- a/renderchan/thumbnailer.py
+++ b/renderchan/thumbnailer.py
@@ -3,6 +3,7 @@ __author__ = 'Ivan Mahonin'
 from gettext import gettext as _
 from argparse import ArgumentParser
 from renderchan.core import RenderChan
+from renderchan import ui
 from renderchan.utils import ini_wrapper
 import os
 import subprocess
@@ -419,6 +420,8 @@ def process_args():
 
 def main(datadir, argv):
     args = process_args()
+
+    ui.set_verbose(True)
     
     if datadir:
         datadir = os.path.abspath(datadir)

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -514,7 +514,7 @@ class ShimmerProgress:
     def set_context(self, text: str) -> None:
         self._context = text
 
-    def set_label(self, text) -> None:
+    def set_label(self, text: str) -> None:
         with self._lock:
             self._label = text
 
@@ -571,6 +571,7 @@ class ShimmerProgress:
         _safe_write(f"{prefix}{_prefix()}{DM}{G['corner_bl']}{RST}{detail}\n")
         _safe_write(f"{_prefix()}\n")
         self._phase_name, self._percent, self._count = "", -1, 0
+        self._label = None
 
     def _render_loop(self) -> None:
         while not self._stop.is_set():

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -444,6 +444,12 @@ def blank() -> None:
         _write("")
 
 
+@_quiet_only
+def quiet_blank() -> None:
+    """Empty line — quiet mode only (pair to blank(), which is verbose-only)."""
+    _write("")
+
+
 def notice(message="") -> None:
     """User-facing info in both modes: plain in verbose, clack line in quiet."""
     if _VERBOSE:

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -159,6 +159,8 @@ def intro(title: str) -> None:
     global _indent
     if _VERBOSE:
         return
+    if _progress is not None:
+        _progress.close_phase()
     _write(f"{DM}{G['corner_tl']}{RST}  {title}")
     _indent += 1
 

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -588,6 +588,7 @@ class ShimmerProgress:
         _safe_write(f"{_prefix()}\n")
         self._phase_name, self._percent, self._count = "", -1, 0
         self._label = None
+        self._msg, self._last_phase = "", ""
 
     def _render_loop(self) -> None:
         while not self._stop.is_set():

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -500,6 +500,7 @@ class ShimmerProgress:
 
         # Current state read by the animation thread
         self._msg = ""
+        self._label = None
         self._anim_percent = -1
         self._anim_count = 0
         self._start = time.monotonic()
@@ -513,6 +514,10 @@ class ShimmerProgress:
     def set_context(self, text: str) -> None:
         self._context = text
 
+    def set_label(self, text) -> None:
+        with self._lock:
+            self._label = text
+
     def on_progress(self, phase: str, current: int = 0, total: int = 0) -> None:
         phase_name = phase
         with self._lock:
@@ -520,6 +525,7 @@ class ShimmerProgress:
                 self._print_phase_done_locked()
             if phase != self._last_phase:
                 self._print_phase_start_locked(phase_name)
+                self._label = None
 
             self._last_phase = phase
             self._phase_name = phase_name
@@ -575,6 +581,7 @@ class ShimmerProgress:
     def _render_frame(self) -> None:
         if not self._msg:
             return
+        msg = self._label or self._msg
         frame = int((time.monotonic() - self._start) / _ANIM_INTERVAL)
         spinner = G["spinner"]
         glyph = spinner[(frame // _FRAMES_PER_GLYPH) % len(spinner)]
@@ -586,13 +593,13 @@ class ShimmerProgress:
             empty = _BAR_WIDTH - filled
             bar = self._render_bar(frame, filled, empty)
             line = (f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
-                    f"{self._msg}  {bar}  {self._anim_percent}%")
+                    f"{msg}  {bar}  {self._anim_percent}%")
         elif self._anim_count > 0:
             count = f"{self._anim_count:,} found".replace(",", " ")
             line = (f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
-                    f"{self._msg}... {count}")
+                    f"{msg}... {count}")
         else:
-            line = f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} {self._msg}..."
+            line = f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} {msg}..."
 
         _safe_write(f"\r\x1b[K{line}")
 
@@ -644,6 +651,13 @@ def progress(phase: str, current: float = 0, total: float = 0) -> None:
 
 
 _tick_counts = {}
+
+
+def progress_label(text: str) -> None:
+    """Update the animated line's label within the current phase (no block change)."""
+    if _VERBOSE or _progress is None:
+        return
+    _progress.set_label(text)
 
 
 def progress_tick(phase: str) -> None:

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -424,6 +424,7 @@ def error(message, stderr=False) -> None:
         print("ERROR: %s" % message, file=stream)
     else:
         _write(f"{_rail()}{RED}{G['err']}{RST} {message}")
+        _write("")
 
 
 # ------------------------------------------------------ shimmer progress ----

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -129,6 +129,12 @@ def is_verbose() -> bool:
     return _VERBOSE
 
 
+def format_duration(seconds: float) -> str:
+    """Format seconds as HH:MM:SS."""
+    t = int(seconds)
+    return "%02d:%02d:%02d" % (t // 3600, (t % 3600) // 60, t % 60)
+
+
 def _write(message: str) -> None:
     if _progress is not None:
         _progress.interrupt()

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -308,14 +308,44 @@ def _write(message: str) -> None:
 
 # --------------------------------------------------- clack-like scaffold ----
 
-def intro(title: str, warn: bool = False) -> None:
+_TITLE_ANIM_DURATION = 0.7   # total reveal time, seconds
+_TITLE_ANIM_INTERVAL = 0.03  # frame tick, seconds
+
+
+def _animate_title(prefix: str, text: str) -> None:
+    """Decode-style reveal: spinner glyphs flicker, then the text appears
+    left to right in their place. The ANSI prefix stays static. TTY only."""
+    if not sys.stdout.isatty():
+        return
+    spinner = G["spinner"]
+    n = len(text)
+    start = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start
+        reveal = int(elapsed / _TITLE_ANIM_DURATION * (n + 1))
+        if reveal >= n:
+            break
+        frame = int(elapsed / 0.15)
+        line = prefix + "".join(
+            text[i] if i < reveal else spinner[(frame + i) % len(spinner)]
+            for i in range(n)
+        )
+        _safe_write("\r\x1b[K" + _prefix() + line)
+        time.sleep(_TITLE_ANIM_INTERVAL)
+    _safe_write("\r\x1b[K")  # leave a clean line for the final static title
+
+
+def intro(title: str, warn: bool = False, animate: bool = False) -> None:
     global _indent
     if _VERBOSE:
         return
     if _progress is not None:
         _progress.close_phase()
     glyph = f"{YLW}{G['warn']}{RST} " if warn else ""
-    _write(f"{DM}{G['corner_tl']}{RST}  {glyph}{title}")
+    static = f"{DM}{G['corner_tl']}{RST}  {glyph}"
+    if animate and sys.stdout.isatty():
+        _animate_title(static, title)
+    _write(static + title)
     _indent += 1
 
 

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -317,9 +317,11 @@ def _safe_write(text: str) -> None:
 
 
 def _write(message: str) -> None:
+    text = _prefix() + message + "\n"
     if _progress is not None:
-        _progress.interrupt()
-    _safe_write(_prefix() + message + "\n")
+        _progress.write_over(text)
+    else:
+        _safe_write(text)
 
 
 # --------------------------------------------------- clack-like scaffold ----
@@ -558,11 +560,12 @@ class ShimmerProgress:
         with self._lock:
             self._print_phase_done_locked()
 
-    def interrupt(self) -> None:
-        """Erase the animation line so a permanent line can be printed cleanly."""
+    def write_over(self, text: str) -> None:
+        """Erase the animation line and write a permanent line atomically."""
         with self._lock:
             if self._tty and self._msg:
                 _safe_write("\r\x1b[K")
+            _safe_write(text)
 
     # ------------------------------------------------------ internals ----
 

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -184,6 +184,100 @@ def compress_paths(paths):
     return out
 
 
+_MAX_PATH_LINE = 90
+
+
+def path_tree_lines(paths):
+    """Render paths as an indented tree of (depth, text) tuples.
+
+    - common directory prefixes collapse into folder lines, but only when
+      the group has 2+ files and renders as more than one line;
+    - numbered sequences in a folder compress via compress_paths();
+    - a group whose content fits a single line flattens into one
+      "dir/name (N files)" file line without a folder;
+    - any emitted line longer than _MAX_PATH_LINE is chunked by path
+      components, preferring the chunk size of the previously printed
+      sibling folder (keeps neighbours visually aligned).
+    """
+    out = []
+    _tree_level([p.split("/") for p in paths], 0, out, [])
+    return out
+
+
+def _common_dir_prefix(groups):
+    prefix = []
+    for comps in zip(*[g[:-1] for g in groups]):
+        if all(c == comps[0] for c in comps):
+            prefix.append(comps[0])
+        else:
+            break
+    return prefix
+
+
+def _choose_chunk(dir_comps, sibling_chunks):
+    for k in reversed(sibling_chunks):
+        if 0 < k <= len(dir_comps) and len("/".join(dir_comps[:k])) <= _MAX_PATH_LINE:
+            return k
+    total = dir_comps[0]
+    k = 1
+    while k < len(dir_comps) and len(total) + 1 + len(dir_comps[k]) <= _MAX_PATH_LINE:
+        total += "/" + dir_comps[k]
+        k += 1
+    return k
+
+
+def _emit_folder(comps, depth, out, sibling_chunks):
+    if len("/".join(comps)) > _MAX_PATH_LINE:
+        chunks = []
+        rest = comps
+        while rest:
+            k = _choose_chunk(rest, sibling_chunks)
+            chunks.append(rest[:k])
+            sibling_chunks.append(k)
+            rest = rest[k:]
+    else:
+        chunks = [comps]
+        sibling_chunks.append(len(comps))
+    for chunk in chunks:
+        out.append((depth, "/".join(chunk) + "/"))
+        depth += 1
+    return depth
+
+
+def _emit_file(comps, depth, out, sibling_chunks):
+    while len(comps) > 1 and len("/".join(comps)) > _MAX_PATH_LINE:
+        k = _choose_chunk(comps[:-1], sibling_chunks)
+        out.append((depth, "/".join(comps[:k]) + "/"))
+        sibling_chunks.append(k)
+        comps = comps[k:]
+        depth += 1
+    out.append((depth, "- " + "/".join(comps)))
+
+
+def _tree_level(groups, depth, out, sibling_chunks):
+    if len(groups) == 1:
+        _emit_file(groups[0], depth, out, sibling_chunks)
+        return
+    prefix = _common_dir_prefix(groups)
+    rest = [g[len(prefix):] for g in groups] if prefix else groups
+    terminals = [g[0] for g in rest if len(g) == 1]
+    subs = {}
+    for g in rest:
+        if len(g) > 1:
+            subs.setdefault(g[0], []).append(g)
+    term_lines = compress_paths(terminals) if terminals else []
+    if not subs and len(term_lines) == 1:
+        # whole group renders as one line - flatten, no folder
+        _emit_file(prefix + [term_lines[0]], depth, out, sibling_chunks)
+        return
+    if prefix:
+        depth = _emit_folder(prefix, depth, out, sibling_chunks)
+    for text in term_lines:
+        out.append((depth, "- " + text))
+    for comp in subs:
+        _tree_level(subs[comp], depth, out, sibling_chunks)
+
+
 _indent = 0  # block nesting depth (quiet mode); each level adds a rail prefix
 
 
@@ -214,13 +308,14 @@ def _write(message: str) -> None:
 
 # --------------------------------------------------- clack-like scaffold ----
 
-def intro(title: str) -> None:
+def intro(title: str, warn: bool = False) -> None:
     global _indent
     if _VERBOSE:
         return
     if _progress is not None:
         _progress.close_phase()
-    _write(f"{DM}{G['corner_tl']}{RST}  {title}")
+    glyph = f"{YLW}{G['warn']}{RST} " if warn else ""
+    _write(f"{DM}{G['corner_tl']}{RST}  {glyph}{title}")
     _indent += 1
 
 
@@ -234,6 +329,18 @@ def outro(message: str = "") -> None:
         _indent -= 1
     _write(f"{DM}{G['corner_bl']}{RST}  {message}")
     _write("")  # separate blocks visually (rail-only line when nested)
+
+
+def section_end() -> None:
+    """Close a block opened by intro() with a bare corner (no message)."""
+    global _indent
+    if _VERBOSE:
+        return
+    if _progress is not None:
+        _progress.close_phase()
+    if _indent > 0:
+        _indent -= 1
+    _write(f"{DM}{G['corner_bl']}{RST}")
 
 
 def log_success(message: str) -> None:

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -118,6 +118,7 @@ def _amber(t: float, dark=AMBER_DARK, bright=AMBER_BRIGHT) -> str:
 # ------------------------------------------------------------- verbosity ----
 
 _VERBOSE = False
+_MUTED = False
 
 
 def set_verbose(flag: bool) -> None:
@@ -127,6 +128,12 @@ def set_verbose(flag: bool) -> None:
 
 def is_verbose() -> bool:
     return _VERBOSE
+
+
+def set_muted(flag: bool) -> None:
+    """Mute warnings (e.g. during a read-only analysis pre-pass)."""
+    global _MUTED
+    _MUTED = bool(flag)
 
 
 def format_duration(seconds: float) -> str:
@@ -146,11 +153,21 @@ def _rail() -> str:
     return f"{DM}{G['rail']}{RST}  " if _indent == 0 else ""
 
 
+def _safe_write(text: str) -> None:
+    try:
+        sys.stdout.write(text)
+        sys.stdout.flush()
+    except BrokenPipeError:
+        # consumer closed the pipe (e.g. `renderchan | head`) - go quietly
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)
+
+
 def _write(message: str) -> None:
     if _progress is not None:
         _progress.interrupt()
-    sys.stdout.write(_prefix() + message + "\n")
-    sys.stdout.flush()
+    _safe_write(_prefix() + message + "\n")
 
 
 # --------------------------------------------------- clack-like scaffold ----
@@ -192,6 +209,13 @@ def log_warn(message: str) -> None:
     if _VERBOSE:
         return
     _write(f"{_rail()}{YLW}{G['warn']}{RST} {message}")
+
+
+def log_line(message: str) -> None:
+    """Plain line at the current indent (list items inside blocks)."""
+    if _VERBOSE:
+        return
+    _write("  " + str(message))
 
 
 def rail_blank() -> None:
@@ -236,6 +260,8 @@ def notice(message="") -> None:
 
 
 def warn(message) -> None:
+    if _MUTED:
+        return
     if _VERBOSE:
         _write("Warning: %s" % message)
     else:
@@ -328,28 +354,24 @@ class ShimmerProgress:
             self._thread.join(timeout=2)
         with self._lock:
             self._print_phase_done_locked()
-            sys.stdout.flush()
 
     def close_phase(self) -> None:
         """Print the done-line of the currently open phase, if any."""
         with self._lock:
             self._print_phase_done_locked()
-            sys.stdout.flush()
 
     def interrupt(self) -> None:
         """Erase the animation line so a permanent line can be printed cleanly."""
         with self._lock:
             if self._tty and self._msg:
-                sys.stdout.write("\r\x1b[K")
-                sys.stdout.flush()
+                _safe_write("\r\x1b[K")
 
     # ------------------------------------------------------ internals ----
 
     def _print_phase_start_locked(self, phase_name: str) -> None:
         prefix = "\r\x1b[K" if self._tty else ""
         title = f"{phase_name} {self._context}" if self._context and _indent == 0 else phase_name
-        sys.stdout.write(f"{prefix}{_prefix()}{DM}{G['corner_tl']}{RST}  {title}\n")
-        sys.stdout.flush()
+        _safe_write(f"{prefix}{_prefix()}{DM}{G['corner_tl']}{RST}  {title}\n")
 
     def _print_phase_done_locked(self) -> None:
         if not self._phase_name:
@@ -359,8 +381,7 @@ class ShimmerProgress:
             detail = "  %s found" % f"{self._count:,}".replace(",", " ")
         else:
             detail = "  done"
-        sys.stdout.write(f"{prefix}{_prefix()}{DM}{G['corner_bl']}{RST}{detail}\n")
-        sys.stdout.flush()
+        _safe_write(f"{prefix}{_prefix()}{DM}{G['corner_bl']}{RST}{detail}\n")
         self._phase_name, self._percent, self._count = "", -1, 0
 
     def _render_loop(self) -> None:
@@ -391,8 +412,7 @@ class ShimmerProgress:
         else:
             line = f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} {self._msg}..."
 
-        sys.stdout.write(f"\r\x1b[K{line}")
-        sys.stdout.flush()
+        _safe_write(f"\r\x1b[K{line}")
 
     def _render_bar(self, frame: int, filled: int, empty: int) -> str:
         if filled == 0:

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -135,49 +135,67 @@ def format_duration(seconds: float) -> str:
     return "%02d:%02d:%02d" % (t // 3600, (t % 3600) // 60, t % 60)
 
 
+_indent = 0  # block nesting depth (quiet mode); each level adds a rail prefix
+
+
+def _prefix() -> str:
+    return "".join(f"{DM}{G['rail']}{RST}  " for _ in range(_indent))
+
+
+def _rail() -> str:
+    return f"{DM}{G['rail']}{RST}  " if _indent == 0 else ""
+
+
 def _write(message: str) -> None:
     if _progress is not None:
         _progress.interrupt()
-    sys.stdout.write(message + "\n")
+    sys.stdout.write(_prefix() + message + "\n")
     sys.stdout.flush()
 
 
 # --------------------------------------------------- clack-like scaffold ----
 
 def intro(title: str) -> None:
+    global _indent
     if _VERBOSE:
         return
     _write(f"{DM}{G['corner_tl']}{RST}  {title}")
+    _indent += 1
 
 
 def outro(message: str = "") -> None:
+    global _indent
     if _VERBOSE:
         return
+    if _progress is not None:
+        _progress.close_phase()
+    if _indent > 0:
+        _indent -= 1
     _write(f"{DM}{G['corner_bl']}{RST}  {message}")
 
 
 def log_success(message: str) -> None:
     if _VERBOSE:
         return
-    _write(f"{DM}{G['rail']}{RST}  {GRN}{G['phase_done']}{RST} {message}")
+    _write(f"{_rail()}{GRN}{G['phase_done']}{RST} {message}")
 
 
 def log_info(message: str) -> None:
     if _VERBOSE:
         return
-    _write(f"{DM}{G['rail']}{RST}  {BLU}{G['info_dot']}{RST} {message}")
+    _write(f"{_rail()}{BLU}{G['info_dot']}{RST} {message}")
 
 
 def log_warn(message: str) -> None:
     if _VERBOSE:
         return
-    _write(f"{DM}{G['rail']}{RST}  {YLW}{G['warn']}{RST} {message}")
+    _write(f"{_rail()}{YLW}{G['warn']}{RST} {message}")
 
 
 def rail_blank() -> None:
     if _VERBOSE:
         return
-    _write(f"{DM}{G['rail']}{RST}")
+    _write(f"{_rail()}")
 
 
 def quiet_subprocess() -> dict:
@@ -219,7 +237,7 @@ def warn(message) -> None:
     if _VERBOSE:
         _write("Warning: %s" % message)
     else:
-        _write(f"{DM}{G['rail']}{RST}  {YLW}{G['warn']}{RST} {message}")
+        _write(f"{_rail()}{YLW}{G['warn']}{RST} {message}")
 
 
 def error(message, stderr=False) -> None:
@@ -227,7 +245,7 @@ def error(message, stderr=False) -> None:
         stream = sys.stderr if stderr else sys.stdout
         print("ERROR: %s" % message, file=stream)
     else:
-        _write(f"{DM}{G['rail']}{RST}  {RED}{G['err']}{RST} {message}")
+        _write(f"{_rail()}{RED}{G['err']}{RST} {message}")
 
 
 # ------------------------------------------------------ shimmer progress ----
@@ -310,6 +328,12 @@ class ShimmerProgress:
             self._print_phase_done_locked()
             sys.stdout.flush()
 
+    def close_phase(self) -> None:
+        """Print the done-line of the currently open phase, if any."""
+        with self._lock:
+            self._print_phase_done_locked()
+            sys.stdout.flush()
+
     def interrupt(self) -> None:
         """Erase the animation line so a permanent line can be printed cleanly."""
         with self._lock:
@@ -321,8 +345,8 @@ class ShimmerProgress:
 
     def _print_phase_start_locked(self, phase_name: str) -> None:
         prefix = "\r\x1b[K" if self._tty else ""
-        title = f"{phase_name} {self._context}" if self._context else phase_name
-        sys.stdout.write(f"{prefix}{DM}{G['corner_tl']}{RST}  {title}\n")
+        title = f"{phase_name} {self._context}" if self._context and _indent == 0 else phase_name
+        sys.stdout.write(f"{prefix}{_prefix()}{DM}{G['corner_tl']}{RST}  {title}\n")
         sys.stdout.flush()
 
     def _print_phase_done_locked(self) -> None:
@@ -333,7 +357,7 @@ class ShimmerProgress:
             detail = "  %s found" % f"{self._count:,}".replace(",", " ")
         else:
             detail = "  done"
-        sys.stdout.write(f"{prefix}{DM}{G['corner_bl']}{RST}{detail}\n")
+        sys.stdout.write(f"{prefix}{_prefix()}{DM}{G['corner_bl']}{RST}{detail}\n")
         sys.stdout.flush()
         self._phase_name, self._percent, self._count = "", -1, 0
 
@@ -356,14 +380,14 @@ class ShimmerProgress:
             filled = round(_BAR_WIDTH * self._anim_percent / 100)
             empty = _BAR_WIDTH - filled
             bar = self._render_bar(frame, filled, empty)
-            line = (f"{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
+            line = (f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
                     f"{self._msg}  {bar}  {self._anim_percent}%")
         elif self._anim_count > 0:
             count = f"{self._anim_count:,} found".replace(",", " ")
-            line = (f"{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
+            line = (f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
                     f"{self._msg}... {count}")
         else:
-            line = f"{DM}{G['rail']}{RST}  {color}{glyph}{RST} {self._msg}..."
+            line = f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} {self._msg}..."
 
         sys.stdout.write(f"\r\x1b[K{line}")
         sys.stdout.flush()

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -18,6 +18,7 @@ main thread is busy rendering.
 import colorsys
 import math
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -140,6 +141,45 @@ def format_duration(seconds: float) -> str:
     """Format seconds as HH:MM:SS."""
     t = int(seconds)
     return "%02d:%02d:%02d" % (t // 3600, (t % 3600) // 60, t % 60)
+
+
+def compress_paths(paths):
+    """Collapse numbered sequences (frame0001.png ...) into ranges for display.
+
+    Runs of >= 3 consecutive numbers sharing dir/prefix/suffix become
+    'dir/prefix{first}-{last}{suffix} (N files)'; everything else stays as-is.
+    """
+    numbered = {}
+    plain = []
+    pat = re.compile(r"^(.*/)?([^\d/]*?)(\d+)([^\d/]*)$")
+    for path in paths:
+        m = pat.match(path)
+        if not m:
+            plain.append(path)
+            continue
+        key = (m.group(1) or '', m.group(2), m.group(4))
+        numbered.setdefault(key, []).append((int(m.group(3)), len(m.group(3))))
+    out = []
+    for (dirn, prefix, suffix), nums in numbered.items():
+        nums = sorted(set(nums))
+        start = prev = nums[0]
+        runs = []
+        for n in nums[1:]:
+            if n[0] == prev[0] + 1:
+                prev = n
+            else:
+                runs.append((start, prev))
+                start = prev = n
+        runs.append((start, prev))
+        for start, end in runs:
+            if end[0] - start[0] + 1 >= 3:
+                out.append("%s%s%0*d-%0*d%s (%d files)" % (
+                    dirn, prefix, start[1], start[0], end[1], end[0], suffix, end[0] - start[0] + 1))
+            else:
+                for n in range(start[0], end[0] + 1):
+                    out.append("%s%s%d%s" % (dirn, prefix, n, suffix))
+    out.extend(plain)
+    return out
 
 
 _indent = 0  # block nesting depth (quiet mode); each level adds a rail prefix

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -152,7 +152,7 @@ def compress_paths(paths):
     """
     numbered = {}
     plain = []
-    pat = re.compile(r"^(.*/)?([^\d/]*?)(\d+)([^\d/]*)$")
+    pat = re.compile(r"^(.*/)?(.*?)(\d+)([^\d/]*)$")  # number = last digit group in basename
     for path in paths:
         m = pat.match(path)
         if not m:
@@ -177,8 +177,9 @@ def compress_paths(paths):
                 out.append("%s%s%0*d-%0*d%s (%d files)" % (
                     dirn, prefix, start[1], start[0], end[1], end[0], suffix, end[0] - start[0] + 1))
             else:
-                for n in range(start[0], end[0] + 1):
-                    out.append("%s%s%d%s" % (dirn, prefix, n, suffix))
+                for n, width in nums:
+                    if start[0] <= n <= end[0]:
+                        out.append("%s%s%0*d%s" % (dirn, prefix, width, n, suffix))
     out.extend(plain)
     return out
 

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -60,7 +60,9 @@ def supports_unicode() -> bool:
             or env.get("TERM") in ("xterm-256color", "alacritty")
             or env.get("TERMINAL_EMULATOR") == "JetBrains-JediTerm"
         )
-    return env.get("TERM") != "linux"
+    if env.get("TERM") in ("linux", "dumb"):
+        return False
+    return "UTF" in (sys.stdout.encoding or "").upper()
 
 
 G = UNICODE_GLYPHS if supports_unicode() else ASCII_GLYPHS

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -1,0 +1,442 @@
+"""
+renderchan/ui.py — console output in the style of the codegraph CLI
+(https://github.com/colbymchenry/codegraph).
+
+Two modes:
+  * default (quiet): clack-style frame (intro/outro, log lines with a rail),
+    animated "shimmer" progress (spinner, bar, percent);
+  * verbose (ui.set_verbose(True)): the historical plain-text RenderChan output.
+
+Fallbacks: non-TTY -> plain lines without ANSI; NO_COLOR/FORCE_COLOR/--no-color;
+Unicode/ASCII glyphs (RENDERCHAN_ASCII=1 / RENDERCHAN_UNICODE=1, TERM=linux,
+Windows terminals).
+
+The animation runs in a background thread, so output does not freeze while the
+main thread is busy rendering.
+"""
+
+import colorsys
+import math
+import os
+import subprocess
+import sys
+import threading
+import time
+
+# ---------------------------------------------------------------- glyphs ----
+
+UNICODE_GLYPHS = {
+    "ok": "✓", "err": "✗", "info": "ℹ", "warn": "⚠",
+    "spinner": ["·", "✢", "✳", "✶", "✻", "✽"],
+    "bar_filled": "█", "bar_empty": "░",
+    "rail": "│", "phase_done": "◆", "dash": "—",
+    "info_dot": "●", "corner_tl": "┌", "corner_bl": "└",
+}
+
+ASCII_GLYPHS = {
+    "ok": "[OK]", "err": "[ERR]", "info": "[i]", "warn": "[!]",
+    "spinner": [".", "*", "+", "x", "o", "O"],
+    "bar_filled": "#", "bar_empty": "-",
+    "rail": "|", "phase_done": "*", "dash": "-",
+    "info_dot": "*", "corner_tl": "+", "corner_bl": "+",
+}
+
+
+def supports_unicode() -> bool:
+    env = os.environ
+    if env.get("RENDERCHAN_ASCII") == "1":
+        return False
+    if env.get("RENDERCHAN_UNICODE") == "1":
+        return True
+    if sys.platform == "win32":
+        return bool(
+            env.get("CI")
+            or env.get("WT_SESSION")                    # Windows Terminal
+            or env.get("TERMINUS_SUBLIME")
+            or env.get("ConEmuTask") == "{cmd::Cmder}"  # ConEmu / cmder
+            or env.get("TERM_PROGRAM") in ("Terminus-Sublime", "vscode")
+            or env.get("TERM") in ("xterm-256color", "alacritty")
+            or env.get("TERMINAL_EMULATOR") == "JetBrains-JediTerm"
+        )
+    return env.get("TERM") != "linux"
+
+
+G = UNICODE_GLYPHS if supports_unicode() else ASCII_GLYPHS
+
+
+# ---------------------------------------------------------------- colors ----
+
+def ansi_colors_enabled() -> bool:
+    """--no-color > --color > NO_COLOR > FORCE_COLOR > TTY > CI > off."""
+    argv = sys.argv
+    if "--no-color" in argv:
+        return False
+    if "--color" in argv:
+        return True
+    if os.environ.get("NO_COLOR"):
+        return False
+    force = os.environ.get("FORCE_COLOR")
+    if force:
+        return force != "0" and force.lower() != "false"
+    if sys.stdout.isatty() and os.environ.get("TERM") != "dumb":
+        return True
+    if os.environ.get("CI"):
+        return True
+    return False
+
+
+COLORS = ansi_colors_enabled()
+
+AMBER_DARK = (160, 100, 9)
+AMBER_BRIGHT = (251, 191, 36)
+
+
+def _derive_bright(dark) -> tuple:
+    h, s, v = colorsys.rgb_to_hsv(*(c / 255 for c in dark))
+    r, g, b = colorsys.hsv_to_rgb(h, s * 0.9, 0.98)
+    return round(r * 255), round(g * 255), round(b * 255)
+
+
+RST = "\x1b[0m" if COLORS else ""
+DM = "\x1b[2m" if COLORS else ""
+BOLD = "\x1b[1m" if COLORS else ""
+GRN = "\x1b[32m" if COLORS else ""
+BLU = "\x1b[34m" if COLORS else ""
+YLW = "\x1b[33m" if COLORS else ""
+RED = "\x1b[31m" if COLORS else ""
+
+
+def _amber(t: float, dark=AMBER_DARK, bright=AMBER_BRIGHT) -> str:
+    if not COLORS:
+        return ""
+    r = round(dark[0] + (bright[0] - dark[0]) * t)
+    g = round(dark[1] + (bright[1] - dark[1]) * t)
+    b = round(dark[2] + (bright[2] - dark[2]) * t)
+    return f"\x1b[38;2;{r};{g};{b}m{BOLD}"
+
+
+# ------------------------------------------------------------- verbosity ----
+
+_VERBOSE = False
+
+
+def set_verbose(flag: bool) -> None:
+    global _VERBOSE
+    _VERBOSE = bool(flag)
+
+
+def is_verbose() -> bool:
+    return _VERBOSE
+
+
+def _write(message: str) -> None:
+    if _progress is not None:
+        _progress.interrupt()
+    sys.stdout.write(message + "\n")
+    sys.stdout.flush()
+
+
+# --------------------------------------------------- clack-like scaffold ----
+
+def intro(title: str) -> None:
+    if _VERBOSE:
+        return
+    _write(f"{DM}{G['corner_tl']}{RST}  {title}")
+
+
+def outro(message: str = "") -> None:
+    if _VERBOSE:
+        return
+    _write(f"{DM}{G['corner_bl']}{RST}  {message}")
+
+
+def log_success(message: str) -> None:
+    if _VERBOSE:
+        return
+    _write(f"{DM}{G['rail']}{RST}  {GRN}{G['phase_done']}{RST} {message}")
+
+
+def log_info(message: str) -> None:
+    if _VERBOSE:
+        return
+    _write(f"{DM}{G['rail']}{RST}  {BLU}{G['info_dot']}{RST} {message}")
+
+
+def log_warn(message: str) -> None:
+    if _VERBOSE:
+        return
+    _write(f"{DM}{G['rail']}{RST}  {YLW}{G['warn']}{RST} {message}")
+
+
+def rail_blank() -> None:
+    if _VERBOSE:
+        return
+    _write(f"{DM}{G['rail']}{RST}")
+
+
+def quiet_subprocess() -> dict:
+    """Kwargs for subprocess.* calls: suppress child output in quiet mode."""
+    if _VERBOSE:
+        return {}
+    return {"stdout": subprocess.DEVNULL, "stderr": subprocess.STDOUT}
+
+
+# ------------------------------------------------------ leveled logging ----
+
+def info(message="") -> None:
+    """Informational chatter — verbose only, plain historical format."""
+    if _VERBOSE:
+        _write(str(message))
+
+
+def debug(message="") -> None:
+    """Debug output — verbose only."""
+    if _VERBOSE:
+        _write(str(message))
+
+
+def blank() -> None:
+    """Empty line — verbose only (used to space out the historical output)."""
+    if _VERBOSE:
+        _write("")
+
+
+def notice(message="") -> None:
+    """User-facing info in both modes: plain in verbose, clack line in quiet."""
+    if _VERBOSE:
+        _write(str(message))
+    else:
+        log_info(str(message))
+
+
+def warn(message) -> None:
+    if _VERBOSE:
+        _write("Warning: %s" % message)
+    else:
+        _write(f"{DM}{G['rail']}{RST}  {YLW}{G['warn']}{RST} {message}")
+
+
+def error(message, stderr=False) -> None:
+    if _VERBOSE:
+        stream = sys.stderr if stderr else sys.stdout
+        print("ERROR: %s" % message, file=stream)
+    else:
+        _write(f"{DM}{G['rail']}{RST}  {RED}{G['err']}{RST} {message}")
+
+
+# ------------------------------------------------------ shimmer progress ----
+
+_ANIM_INTERVAL = 0.15      # 150 ms per frame
+_FRAMES_PER_GLYPH = 3
+_BAR_WIDTH = 25
+_CYCLE_FRAMES = 24
+_SHIMMER_WIDTH = 3
+
+
+class ShimmerProgress:
+    """Animated per-phase progress.
+
+    Usage:
+        progress = ShimmerProgress()
+        progress.on_progress("Rendering", current=i, total=n)
+        ...
+        progress.stop()   # prints the final "◆ Phase — done" line
+
+    Custom gradient:
+        ShimmerProgress(gradient=(0, 100, 200))                     # bright derived
+        ShimmerProgress(gradient=((0, 100, 200), (200, 200, 255)))  # explicit pair
+    """
+
+    def __init__(self, gradient=None) -> None:
+        if gradient is None:
+            self._dark, self._bright = AMBER_DARK, AMBER_BRIGHT
+        elif isinstance(gradient[0], int):      # single color: derive bright
+            self._dark, self._bright = gradient, _derive_bright(gradient)
+        else:                                   # explicit (dark, bright) pair
+            self._dark, self._bright = gradient
+        self._tty = sys.stdout.isatty()
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = None
+
+        self._last_phase = ""
+        self._phase_name = ""
+        self._percent = -1
+        self._count = 0
+        self._context = ""
+
+        # Current state read by the animation thread
+        self._msg = ""
+        self._anim_percent = -1
+        self._anim_count = 0
+        self._start = time.monotonic()
+
+        if self._tty:
+            self._thread = threading.Thread(target=self._render_loop, daemon=True)
+            self._thread.start()
+
+    # ---------------------------------------------------------- API ----
+
+    def set_context(self, text: str) -> None:
+        self._context = text
+
+    def on_progress(self, phase: str, current: int = 0, total: int = 0) -> None:
+        phase_name = phase
+        with self._lock:
+            if self._last_phase and phase != self._last_phase:
+                self._print_phase_done_locked()
+            if phase != self._last_phase:
+                self._print_phase_start_locked(phase_name)
+
+            self._last_phase = phase
+            self._phase_name = phase_name
+
+            percent = round(current / total * 100) if total > 0 else -1
+            count = current if total <= 0 and current > 0 else 0
+            self._percent, self._count = percent, count
+            self._msg, self._anim_percent, self._anim_count = phase_name, percent, count
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        with self._lock:
+            self._print_phase_done_locked()
+            sys.stdout.flush()
+
+    def interrupt(self) -> None:
+        """Erase the animation line so a permanent line can be printed cleanly."""
+        with self._lock:
+            if self._tty and self._msg:
+                sys.stdout.write("\r\x1b[K")
+                sys.stdout.flush()
+
+    # ------------------------------------------------------ internals ----
+
+    def _print_phase_start_locked(self, phase_name: str) -> None:
+        prefix = "\r\x1b[K" if self._tty else ""
+        title = f"{phase_name} {self._context}" if self._context else phase_name
+        sys.stdout.write(f"{prefix}{DM}{G['corner_tl']}{RST}  {title}\n")
+        sys.stdout.flush()
+
+    def _print_phase_done_locked(self) -> None:
+        if not self._phase_name:
+            return
+        prefix = "\r\x1b[K" if self._tty else ""
+        if self._count > 0:
+            detail = "  %s found" % f"{self._count:,}".replace(",", " ")
+        else:
+            detail = "  done"
+        sys.stdout.write(f"{prefix}{DM}{G['corner_bl']}{RST}{detail}\n")
+        sys.stdout.flush()
+        self._phase_name, self._percent, self._count = "", -1, 0
+
+    def _render_loop(self) -> None:
+        while not self._stop.is_set():
+            with self._lock:
+                self._render_frame()
+            time.sleep(0.05)  # 50 ms render tick
+
+    def _render_frame(self) -> None:
+        if not self._msg:
+            return
+        frame = int((time.monotonic() - self._start) / _ANIM_INTERVAL)
+        spinner = G["spinner"]
+        glyph = spinner[(frame // _FRAMES_PER_GLYPH) % len(spinner)]
+        t = (math.sin(frame * 2 * math.pi / 13) + 1) / 2
+        color = _amber(t, self._dark, self._bright)
+
+        if self._anim_percent >= 0:
+            filled = round(_BAR_WIDTH * self._anim_percent / 100)
+            empty = _BAR_WIDTH - filled
+            bar = self._render_bar(frame, filled, empty)
+            line = (f"{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
+                    f"{self._msg}  {bar}  {self._anim_percent}%")
+        elif self._anim_count > 0:
+            count = f"{self._anim_count:,} found".replace(",", " ")
+            line = (f"{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
+                    f"{self._msg}... {count}")
+        else:
+            line = f"{DM}{G['rail']}{RST}  {color}{glyph}{RST} {self._msg}..."
+
+        sys.stdout.write(f"\r\x1b[K{line}")
+        sys.stdout.flush()
+
+    def _render_bar(self, frame: int, filled: int, empty: int) -> str:
+        if filled == 0:
+            return f"{DM}{G['bar_empty'] * empty}{RST}"
+        shimmer_pos = ((frame % _CYCLE_FRAMES) / _CYCLE_FRAMES) * (filled + 6) - 3
+        out = []
+        for i in range(filled):
+            if not COLORS:
+                out.append(G["bar_filled"])
+                continue
+            dist = abs(i - shimmer_pos)
+            t = max(0.0, 1 - dist / _SHIMMER_WIDTH)
+            out.append(f"{_amber(t, self._dark, self._bright)}{G['bar_filled']}")
+        out.append(f"{RST}{DM}{G['bar_empty'] * empty}{RST}")
+        return "".join(out)
+
+
+# ----------------------------------------------------- progress plumbing ----
+
+_progress = None
+_progress_context = ""
+
+
+def progress_context(text: str) -> None:
+    """Set the context suffix for phase block titles (e.g. 'scroll.sif to .png')."""
+    global _progress_context
+    _progress_context = text
+    if _progress is not None:
+        _progress.set_context(text)
+
+
+def progress_start() -> None:
+    """Start the shared shimmer animation (quiet mode only)."""
+    global _progress
+    if _VERBOSE:
+        return
+    if _progress is None:
+        _progress = ShimmerProgress()
+        _progress.set_context(_progress_context)
+
+
+def progress(phase: str, current: float = 0, total: float = 0) -> None:
+    """Report progress; no-op in verbose mode (callers print there instead)."""
+    if _VERBOSE or _progress is None:
+        return
+    _progress.on_progress(phase, round(current), round(total))
+
+
+_tick_counts = {}
+
+
+def progress_tick(phase: str) -> None:
+    """Count-mode progress: 'Resolving dependencies... 12 found'."""
+    if _VERBOSE or _progress is None:
+        return
+    _tick_counts[phase] = _tick_counts.get(phase, 0) + 1
+    _progress.on_progress(phase, _tick_counts[phase], 0)
+
+
+def progress_stop() -> None:
+    global _progress
+    if _progress is not None:
+        _progress.stop()
+        _progress = None
+    _tick_counts.clear()
+
+
+if __name__ == "__main__":
+    intro("RenderChan")
+    log_info("scene.sif")
+    progress_start()
+    for i in range(0, 101, 5):
+        progress("Rendering", i, 100)
+        time.sleep(0.05)
+    progress("Merging", 100, 100)
+    time.sleep(0.3)
+    progress_stop()
+    warn("something looks odd")
+    outro("Completed in 00:00:01")

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -98,6 +98,7 @@ def _derive_bright(dark) -> tuple:
     return round(r * 255), round(g * 255), round(b * 255)
 
 
+AMBER = "\x1b[38;2;251;191;36m" if COLORS else ""  # bright end of the progress-bar gradient
 RST = "\x1b[0m" if COLORS else ""
 DM = "\x1b[2m" if COLORS else ""
 BOLD = "\x1b[1m" if COLORS else ""
@@ -231,6 +232,7 @@ def outro(message: str = "") -> None:
     if _indent > 0:
         _indent -= 1
     _write(f"{DM}{G['corner_bl']}{RST}  {message}")
+    _write("")  # separate blocks visually (rail-only line when nested)
 
 
 def log_success(message: str) -> None:
@@ -242,7 +244,7 @@ def log_success(message: str) -> None:
 def log_info(message: str) -> None:
     if _VERBOSE:
         return
-    _write(f"{_rail()}{BLU}{G['info_dot']}{RST} {message}")
+    _write(f"{_rail()}{AMBER}{G['info_dot']}{RST} {message}")
 
 
 def log_warn(message: str) -> None:
@@ -296,7 +298,7 @@ def notice(message="") -> None:
     if _VERBOSE:
         _write(str(message))
     else:
-        log_info(str(message))
+        _write(f"{_rail()}{BLU}{G['info_dot']}{RST} {message}")
 
 
 def warn(message) -> None:
@@ -410,7 +412,7 @@ class ShimmerProgress:
 
     def _print_phase_start_locked(self, phase_name: str) -> None:
         prefix = "\r\x1b[K" if self._tty else ""
-        title = f"{phase_name} {self._context}" if self._context and _indent == 0 else phase_name
+        title = f"{phase_name} {self._context}" if self._context and _indent <= 1 else phase_name
         _safe_write(f"{prefix}{_prefix()}{DM}{G['corner_tl']}{RST}  {title}\n")
 
     def _print_phase_done_locked(self) -> None:
@@ -422,6 +424,7 @@ class ShimmerProgress:
         else:
             detail = "  done"
         _safe_write(f"{prefix}{_prefix()}{DM}{G['corner_bl']}{RST}{detail}\n")
+        _safe_write(f"{_prefix()}\n")
         self._phase_name, self._percent, self._count = "", -1, 0
 
     def _render_loop(self) -> None:

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -16,6 +16,7 @@ main thread is busy rendering.
 """
 
 import colorsys
+import functools
 import math
 import os
 import re
@@ -136,6 +137,26 @@ def set_muted(flag: bool) -> None:
     """Mute warnings (e.g. during a read-only analysis pre-pass)."""
     global _MUTED
     _MUTED = bool(flag)
+
+
+def _quiet_only(func):
+    """Skip the call in verbose mode (quiet-mode-only output)."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if _VERBOSE:
+            return
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def _needs_progress(func):
+    """Skip the call when the shared shimmer animation is not running."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if _progress is None:
+            return
+        return func(*args, **kwargs)
+    return wrapper
 
 
 def format_duration(seconds: float) -> str:
@@ -335,12 +356,15 @@ def _animate_title(prefix: str, text: str) -> None:
     _safe_write("\r\x1b[K")  # leave a clean line for the final static title
 
 
-def intro(title: str, warn: bool = False, animate: bool = False) -> None:
-    global _indent
-    if _VERBOSE:
-        return
+def _close_progress() -> None:
     if _progress is not None:
         _progress.close_phase()
+
+
+@_quiet_only
+def intro(title: str, warn: bool = False, animate: bool = False) -> None:
+    global _indent
+    _close_progress()
     glyph = f"{YLW}{G['warn']}{RST} " if warn else ""
     static = f"{DM}{G['corner_tl']}{RST}  {glyph}"
     if animate and sys.stdout.isatty():
@@ -349,58 +373,51 @@ def intro(title: str, warn: bool = False, animate: bool = False) -> None:
     _indent += 1
 
 
+@_quiet_only
 def outro(message: str = "") -> None:
     global _indent
-    if _VERBOSE:
-        return
-    if _progress is not None:
-        _progress.close_phase()
+    _close_progress()
     if _indent > 0:
         _indent -= 1
     _write(f"{DM}{G['corner_bl']}{RST}  {message}")
     _write("")  # separate blocks visually (rail-only line when nested)
 
 
+@_quiet_only
 def section_end() -> None:
     """Close a block opened by intro() with a bare corner (no message)."""
     global _indent
-    if _VERBOSE:
-        return
-    if _progress is not None:
-        _progress.close_phase()
+    _close_progress()
     if _indent > 0:
         _indent -= 1
     _write(f"{DM}{G['corner_bl']}{RST}")
 
 
+@_quiet_only
+def _log_glyph(color: str, glyph: str, message) -> None:
+    _write(f"{_rail()}{color}{glyph}{RST} {message}")
+
+
 def log_success(message: str) -> None:
-    if _VERBOSE:
-        return
-    _write(f"{_rail()}{GRN}{G['phase_done']}{RST} {message}")
+    _log_glyph(GRN, G['phase_done'], message)
 
 
 def log_info(message: str) -> None:
-    if _VERBOSE:
-        return
-    _write(f"{_rail()}{AMBER}{G['info_dot']}{RST} {message}")
+    _log_glyph(AMBER, G['info_dot'], message)
 
 
 def log_warn(message: str) -> None:
-    if _VERBOSE:
-        return
-    _write(f"{_rail()}{YLW}{G['warn']}{RST} {message}")
+    _log_glyph(YLW, G['warn'], message)
 
 
+@_quiet_only
 def log_line(message: str) -> None:
     """Plain line at the current indent (list items inside blocks)."""
-    if _VERBOSE:
-        return
     _write("  " + str(message))
 
 
+@_quiet_only
 def rail_blank() -> None:
-    if _VERBOSE:
-        return
     _write(f"{_rail()}")
 
 
@@ -421,8 +438,7 @@ def info(message="") -> None:
 
 def debug(message="") -> None:
     """Debug output — verbose only."""
-    if _VERBOSE:
-        _write(str(message))
+    info(message)
 
 
 def blank() -> None:
@@ -436,7 +452,7 @@ def notice(message="") -> None:
     if _VERBOSE:
         _write(str(message))
     else:
-        _write(f"{_rail()}{BLU}{G['info_dot']}{RST} {message}")
+        _log_glyph(BLU, G['info_dot'], message)
 
 
 def warn(message) -> None:
@@ -445,7 +461,7 @@ def warn(message) -> None:
     if _VERBOSE:
         _write("Warning: %s" % message)
     else:
-        _write(f"{_rail()}{YLW}{G['warn']}{RST} {message}")
+        _log_glyph(YLW, G['warn'], message)
 
 
 def error(message, stderr=False) -> None:
@@ -512,28 +528,28 @@ class ShimmerProgress:
     # ---------------------------------------------------------- API ----
 
     def set_context(self, text: str) -> None:
-        self._context = text
+        with self._lock:
+            self._context = text
 
     def set_label(self, text: str) -> None:
         with self._lock:
             self._label = text
 
     def on_progress(self, phase: str, current: int = 0, total: int = 0) -> None:
-        phase_name = phase
         with self._lock:
             if self._last_phase and phase != self._last_phase:
                 self._print_phase_done_locked()
             if phase != self._last_phase:
-                self._print_phase_start_locked(phase_name)
+                self._print_phase_start_locked(phase)
                 self._label = None
 
             self._last_phase = phase
-            self._phase_name = phase_name
+            self._phase_name = phase
 
             percent = round(current / total * 100) if total > 0 else -1
             count = current if total <= 0 and current > 0 else 0
             self._percent, self._count = percent, count
-            self._msg, self._anim_percent, self._anim_count = phase_name, percent, count
+            self._msg, self._anim_percent, self._anim_count = phase, percent, count
 
     def stop(self) -> None:
         self._stop.set()
@@ -589,18 +605,17 @@ class ShimmerProgress:
         t = (math.sin(frame * 2 * math.pi / 13) + 1) / 2
         color = _amber(t, self._dark, self._bright)
 
+        head = f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
         if self._anim_percent >= 0:
             filled = round(_BAR_WIDTH * self._anim_percent / 100)
             empty = _BAR_WIDTH - filled
             bar = self._render_bar(frame, filled, empty)
-            line = (f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
-                    f"{msg}  {bar}  {self._anim_percent}%")
+            line = f"{head}{msg}  {bar}  {self._anim_percent}%"
         elif self._anim_count > 0:
             count = f"{self._anim_count:,} found".replace(",", " ")
-            line = (f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} "
-                    f"{msg}... {count}")
+            line = f"{head}{msg}... {count}"
         else:
-            line = f"{_prefix()}{DM}{G['rail']}{RST}  {color}{glyph}{RST} {msg}..."
+            line = f"{head}{msg}..."
 
         _safe_write(f"\r\x1b[K{line}")
 
@@ -634,37 +649,36 @@ def progress_context(text: str) -> None:
         _progress.set_context(text)
 
 
+@_quiet_only
 def progress_start() -> None:
     """Start the shared shimmer animation (quiet mode only)."""
     global _progress
-    if _VERBOSE:
-        return
     if _progress is None:
         _progress = ShimmerProgress()
         _progress.set_context(_progress_context)
 
 
+@_quiet_only
+@_needs_progress
 def progress(phase: str, current: float = 0, total: float = 0) -> None:
     """Report progress; no-op in verbose mode (callers print there instead)."""
-    if _VERBOSE or _progress is None:
-        return
     _progress.on_progress(phase, round(current), round(total))
 
 
 _tick_counts = {}
 
 
+@_quiet_only
+@_needs_progress
 def progress_label(text: str) -> None:
     """Update the animated line's label within the current phase (no block change)."""
-    if _VERBOSE or _progress is None:
-        return
     _progress.set_label(text)
 
 
+@_quiet_only
+@_needs_progress
 def progress_tick(phase: str) -> None:
     """Count-mode progress: 'Resolving dependencies... 12 found'."""
-    if _VERBOSE or _progress is None:
-        return
     _tick_counts[phase] = _tick_counts.get(phase, 0) + 1
     _progress.on_progress(phase, _tick_counts[phase], 0)
 

--- a/renderchan/ui.py
+++ b/renderchan/ui.py
@@ -7,7 +7,7 @@ Two modes:
     animated "shimmer" progress (spinner, bar, percent);
   * verbose (ui.set_verbose(True)): the historical plain-text RenderChan output.
 
-Fallbacks: non-TTY -> plain lines without ANSI; NO_COLOR/FORCE_COLOR/--no-color;
+Fallbacks: non-TTY -> plain lines without ANSI; NO_COLOR/FORCE_COLOR;
 Unicode/ASCII glyphs (RENDERCHAN_ASCII=1 / RENDERCHAN_UNICODE=1, TERM=linux,
 Windows terminals).
 
@@ -69,12 +69,7 @@ G = UNICODE_GLYPHS if supports_unicode() else ASCII_GLYPHS
 # ---------------------------------------------------------------- colors ----
 
 def ansi_colors_enabled() -> bool:
-    """--no-color > --color > NO_COLOR > FORCE_COLOR > TTY > CI > off."""
-    argv = sys.argv
-    if "--no-color" in argv:
-        return False
-    if "--color" in argv:
-        return True
+    """NO_COLOR > FORCE_COLOR > TTY > CI > off."""
     if os.environ.get("NO_COLOR"):
         return False
     force = os.environ.get("FORCE_COLOR")

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -6,6 +6,7 @@ import time
 import threading
 import io
 import shutil
+from renderchan import ui
 
 if os.name == 'nt':
     import ctypes
@@ -112,7 +113,7 @@ def sync(profile_output, output, compareTime=None):
                 output_str=output
                 if len(output_str)>60:
                     output_str="..."+output_str[-60:]
-                print(". . Syncing profile data for %s" % output_str)
+                ui.info(". . Syncing profile data for %s" % output_str)
 
             if not os.path.exists(os.path.dirname(output)):
                     mkdirs(os.path.dirname(output))
@@ -128,7 +129,7 @@ def sync(profile_output, output, compareTime=None):
                         else:
                             os.remove(output)
                     except:
-                        print("Failed to remove %s... Trying again..." % output)
+                        ui.warn("Failed to remove %s... Trying again..." % output)
                         pass
                 rename_success=False
                 while not rename_success:
@@ -136,7 +137,7 @@ def sync(profile_output, output, compareTime=None):
                         os.rename(output_tmp, output)
                         rename_success=True
                     except:
-                        print("Failed to rename %s -> %s... Trying again..." % (output_tmp, output))
+                        ui.warn("Failed to rename %s -> %s... Trying again..." % (output_tmp, output))
                         pass
             else:
                 if os.path.exists(output):
@@ -157,7 +158,7 @@ def sync(profile_output, output, compareTime=None):
                     try:
                         os.link(profile_output, output)
                     except:
-                        print("Warning: Cannot create a symlink.")
+                        ui.warn("Cannot create a symlink.")
                         try:
                             shutil.copyfile(profile_output, output)
                         except:


### PR DESCRIPTION
Reworks console output: a new renderchan/ui.py module with two modes — quiet (default): clack-style blocks with an animated shimmer progress bar; verbose (--verbose): the historical plain-text output. Secondary entry points (job-launcher, manager, thumbnailer, httpserver) keep the old output unconditionally.


https://github.com/user-attachments/assets/05921476-9695-4c09-8bba-d173cab1af3c

