### PR TITLE
fix: verify hardlinks on network filesystems

### DIFF
--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -10,6 +10,7 @@ from renderchan.utils import float_trunc
 from renderchan.utils import sync
 from renderchan.utils import touch
 from renderchan.utils import copytree
+from renderchan.utils import link_or_copy
 from renderchan.utils import which
 from renderchan.utils import is_true_string
 from renderchan import ui
@@ -1040,14 +1041,16 @@ class RenderChan():
             if m and total_frames > 0:
                 ui.progress(phase, min(int(m.group(1)), total_frames), total_frames)
         rc = proc.wait()
-        if rc != 0:
-            errlog.seek(0)
-            tail = errlog.read().decode("utf-8", errors="replace").splitlines()
-            errlog.close()
-            for line in tail[-10:]:
-                ui.error(line)
-            raise subprocess.CalledProcessError(rc, cmd)
+        errlog.seek(0)
+        log = errlog.read().decode("utf-8", errors="replace")
         errlog.close()
+        # image2 demuxer stops at the first unreadable frame but still exits 0,
+        # silently producing a shorter video - treat that as a failure
+        if rc == 0 and "Could not open file" not in log and "Conversion failed" not in log:
+            return
+        for line in log.splitlines()[-10:]:
+            ui.error(line)
+        raise subprocess.CalledProcessError(rc or 1, cmd)
 
     def job_render(self, taskfile, format, updateCompletion, start=None, end=None, compare_time=None):
         """
@@ -1226,7 +1229,7 @@ class RenderChan():
                                         dst_file_path = os.path.join(dst_dir, new_filename)
                                         try:
                                             if not os.path.isdir(src_file_path):
-                                                os.link(src_file_path, dst_file_path)
+                                                link_or_copy(src_file_path, dst_file_path)
                                         except (IOError, os.error) as why:
                                             errors.append((src_file_path, dst_file_path, str(why)))
                                         # catch the Error from the recursive copytree so that we can

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -31,6 +31,32 @@ def which(program):
 
     return None
 
+_hardlinks_broken = False
+
+def link_or_copy(src, dst):
+    """Hardlink src to dst, falling back to a real copy.
+
+    On CIFS mounts a fresh hardlink can be unreadable for a second or two
+    (attribute cache) or broken entirely, while os.link() itself reports
+    success - so the link is verified by actually reading it."""
+    global _hardlinks_broken
+    if not _hardlinks_broken:
+        try:
+            os.link(src, dst)
+        except OSError:
+            _hardlinks_broken = True
+        else:
+            for _ in range(10):  # up to ~3 s for the link to become readable
+                try:
+                    with open(dst, 'rb') as f:
+                        f.read(1)
+                    return
+                except OSError:
+                    time.sleep(0.3)
+            os.remove(dst)
+            _hardlinks_broken = True
+    shutil.copy2(src, dst)
+
 def copytree(src, dst, symlinks=False, hardlinks=False, ignore=None):
     names = os.listdir(src)
     if ignore is not None:
@@ -53,7 +79,7 @@ def copytree(src, dst, symlinks=False, hardlinks=False, ignore=None):
             elif os.path.isdir(srcname):
                 copytree(srcname, dstname, symlinks, hardlinks, ignore)
             elif hardlinks:
-                os.link(srcname, dstname)
+                link_or_copy(srcname, dstname)
             else:
                 shutil.copy2(srcname, dstname)
             # XXX What about devices, sockets etc.?
@@ -156,12 +182,8 @@ def sync(profile_output, output, compareTime=None):
                             raise Exception('ERROR: Cannot sync profile data.')
                 else:
                     try:
-                        os.link(profile_output, output)
+                        link_or_copy(profile_output, output)
                     except:
-                        ui.warn("Cannot create a symlink.")
-                        try:
-                            shutil.copyfile(profile_output, output)
-                        except:
                             raise Exception('ERROR: Cannot sync profile data.')
 
             if not os.path.exists(output):


### PR DESCRIPTION
When merging on a network drive (CIFS), the resulting .mov was silently shorter than expected: ffmpeg stopped reading the PNG sequence on a freshly created hardlink, which on CIFS stays unreadable for ~1-2 seconds after creation, and still exited with code 0 — so the error was never shown.

***Solution:***
- New utils.link_or_copy(): after os.link() verifies the file by reading it (with retries, ~3 s), falling back to a real copy on failure. Used in frame merging, copytree(hardlinks=True) and sync().
- run_ffmpeg_progress now treats Could not open file / Conversion failed in the ffmpeg log as a failure even when the exit code is 0: it prints the log tail and aborts the merge (no .done marker, so the next run re-merges).